### PR TITLE
fix: convert ACL values to native Python types for JSON serialization

### DIFF
--- a/custom_components/matter_binding_helper/matter_client.py
+++ b/custom_components/matter_binding_helper/matter_client.py
@@ -1501,26 +1501,43 @@ async def get_acl(hass: HomeAssistant, node_id: int) -> list[ACLEntry]:
                     for t in raw_targets:
                         # Handle multiple key formats for targets
                         # TLV tags: 0=cluster, 1=endpoint, 2=deviceType
+                        # Convert to native Python int for JSON serialization
+                        cluster_val = _get_value(
+                            t, "0", 0, "cluster", "Cluster", default=None
+                        )
+                        endpoint_val = _get_value(
+                            t, "1", 1, "endpoint", "Endpoint", default=None
+                        )
+                        device_type_val = _get_value(
+                            t, "2", 2, "deviceType", "DeviceType", default=None
+                        )
                         targets.append(
                             ACLTarget(
-                                cluster=_get_value(
-                                    t, "0", 0, "cluster", "Cluster", default=None
-                                ),
-                                endpoint=_get_value(
-                                    t, "1", 1, "endpoint", "Endpoint", default=None
-                                ),
-                                device_type=_get_value(
-                                    t, "2", 2, "deviceType", "DeviceType", default=None
-                                ),
+                                cluster=int(cluster_val)
+                                if cluster_val is not None
+                                else None,
+                                endpoint=int(endpoint_val)
+                                if endpoint_val is not None
+                                else None,
+                                device_type=int(device_type_val)
+                                if device_type_val is not None
+                                else None,
                             )
                         )
 
+                # Convert subjects to native Python ints for JSON serialization
+                # (Matter SDK may return numpy int64 or chip-specific types)
+                subjects_list = []
+                if isinstance(subjects, list):
+                    for s in subjects:
+                        subjects_list.append(int(s) if s is not None else None)
+
                 acl_entry = ACLEntry(
-                    privilege=privilege,
-                    auth_mode=auth_mode,
-                    subjects=subjects if isinstance(subjects, list) else [],
+                    privilege=int(privilege) if privilege is not None else 0,
+                    auth_mode=int(auth_mode) if auth_mode is not None else 0,
+                    subjects=subjects_list,
                     targets=targets,
-                    fabric_index=fabric_index,
+                    fabric_index=int(fabric_index) if fabric_index is not None else 0,
                 )
                 acl_entries.append(acl_entry)
 


### PR DESCRIPTION
## Summary

Fixes "Invalid JSON in response" error when loading ACL entries.

## Problem

Matter SDK may return numpy int64 or chip-specific integer types that Python's JSON encoder cannot serialize, causing:
```
{"code":"unknown_error","message":"Invalid JSON in response"}
```

## Solution

Explicitly convert all integer values to native Python `int` types before storing in ACL dataclasses:
- `privilege`, `auth_mode`, `fabric_index`
- Each subject in the `subjects` list
- `cluster`, `endpoint`, `device_type` in ACLTarget

## Test plan

- [ ] Load ACL entries for a commissioned device
- [ ] Verify no JSON serialization errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and consistency of access control list (ACL) entry handling to ensure reliable processing across different data sources.

* **Improvements**
  * Enhanced logging clarity around access control entry construction for better troubleshooting visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->