### PR TITLE
fix: handle Matter SDK Nullable type in ACL target parsing

### DIFF
--- a/custom_components/matter_binding_helper/matter_client.py
+++ b/custom_components/matter_binding_helper/matter_client.py
@@ -1476,6 +1476,21 @@ async def get_acl(hass: HomeAssistant, node_id: int) -> list[ACLEntry]:
                                     return val
                     return default
 
+                def _safe_int(val) -> int | None:
+                    """Convert value to int, handling Nullable and other special types."""
+                    if val is None:
+                        return None
+                    # Check for Matter SDK Nullable type (has a Null attribute)
+                    if hasattr(val, "Null"):
+                        return None
+                    # Check for NullValue class name pattern
+                    if type(val).__name__ in ("Nullable", "NullValue"):
+                        return None
+                    try:
+                        return int(val)
+                    except (TypeError, ValueError):
+                        return None
+
                 privilege = _get_value(
                     entry, "1", 1, "privilege", "Privilege", default=0
                 )
@@ -1513,15 +1528,9 @@ async def get_acl(hass: HomeAssistant, node_id: int) -> list[ACLEntry]:
                         )
                         targets.append(
                             ACLTarget(
-                                cluster=int(cluster_val)
-                                if cluster_val is not None
-                                else None,
-                                endpoint=int(endpoint_val)
-                                if endpoint_val is not None
-                                else None,
-                                device_type=int(device_type_val)
-                                if device_type_val is not None
-                                else None,
+                                cluster=_safe_int(cluster_val),
+                                endpoint=_safe_int(endpoint_val),
+                                device_type=_safe_int(device_type_val),
                             )
                         )
 


### PR DESCRIPTION
## Summary

The Matter SDK uses `Nullable` wrapper types for optional values. Add `_safe_int` helper that properly handles `Nullable`, `NullValue`, and other special types.

## Problem

```
Error reading ACL for node 11: int() argument must be a string, a bytes-like object or a real number, not 'Nullable'
```

## Solution

Added `_safe_int()` helper that:
- Checks for Matter SDK `Nullable` type (has `Null` attribute)
- Checks for `NullValue` class name pattern
- Falls back to try/except for safe conversion

## Test plan

- [ ] Verify ACL reading works for devices with Nullable target fields