### PR TITLE
feat: add ACL verification polling with progress feedback

### DIFF
--- a/custom_components/matter_binding_helper/const.py
+++ b/custom_components/matter_binding_helper/const.py
@@ -82,6 +82,11 @@ ACL_AUTH_MODE_PASE = 1  # Commissioning
 ACL_AUTH_MODE_CASE = 2  # Device-to-device (certificate)
 ACL_AUTH_MODE_GROUP = 3  # Group messaging
 
+# ACL provisioning progress events
+EVENT_ACL_PROGRESS = f"{DOMAIN}_acl_progress"
+ACL_VERIFY_TIMEOUT = 30  # seconds
+ACL_VERIFY_INTERVAL = 2  # seconds
+
 # Cluster-to-privilege mapping for bindings
 # Maps cluster IDs to the minimum privilege required to operate on them
 CLUSTER_DOOR_LOCK = 0x0101

--- a/custom_components/matter_binding_helper/matter_client.py
+++ b/custom_components/matter_binding_helper/matter_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
@@ -21,6 +22,8 @@ from .const import (
     ACL_PRIVILEGE_OPERATE,
     ACL_PRIVILEGE_PROXY_VIEW,
     ACL_PRIVILEGE_VIEW,
+    ACL_VERIFY_INTERVAL,
+    ACL_VERIFY_TIMEOUT,
     ATTR_ACL,
     ATTR_ACCEPTED_COMMAND_LIST,
     ATTR_CLIENT_LIST,
@@ -37,6 +40,7 @@ from .const import (
     DEFAULT_CLUSTER_PRIVILEGE,
     DEFAULT_DEMO_MODE,
     DOMAIN,
+    EVENT_ACL_PROGRESS,
 )
 
 if TYPE_CHECKING:
@@ -2329,41 +2333,116 @@ async def add_acl_entry(
         if not write_result.success:
             return write_result
 
-        # Read-after-write verification: confirm the entry was actually persisted
+        # Read-after-write verification with polling: some devices take time to process ACL writes
+        max_attempts = ACL_VERIFY_TIMEOUT // ACL_VERIFY_INTERVAL
+
         _LOGGER.debug(
-            "add_acl_entry: Verifying ACL entry was persisted for node %s", node_id
-        )
-        verified_entries = await get_acl(hass, node_id)
-
-        if not _acl_entry_exists(
-            verified_entries, source_node_id, target_endpoint_id, cluster_id
-        ):
-            _LOGGER.error(
-                "add_acl_entry: VERIFICATION FAILED - ACL entry not found after write! "
-                "source_node=%s, target_node=%s, endpoint=%s, cluster=0x%04X. "
-                "Device may have rejected the entry silently.",
-                source_node_id,
-                node_id,
-                target_endpoint_id,
-                cluster_id,
-            )
-            return ACLProvisioningResult(
-                success=False,
-                message="ACL write appeared to succeed but entry not found on device. "
-                "The device may have rejected the entry.",
-                acl_entries_count=len(verified_entries),
-                error_type=OperationErrorType.DEVICE_REJECTED,
-            )
-
-        _LOGGER.info(
-            "add_acl_entry: Verified ACL entry persisted on node %s (%d total entries)",
+            "add_acl_entry: Verifying ACL entry was persisted for node %s (polling up to %ds)",
             node_id,
-            len(verified_entries),
+            ACL_VERIFY_TIMEOUT,
+        )
+
+        # Fire initial progress event
+        hass.bus.async_fire(
+            EVENT_ACL_PROGRESS,
+            {
+                "target_node_id": node_id,
+                "source_node_id": source_node_id,
+                "status": "verifying",
+                "attempt": 0,
+                "max_attempts": max_attempts,
+                "timeout_seconds": ACL_VERIFY_TIMEOUT,
+                "message": "Verifying ACL was saved to device...",
+            },
+        )
+
+        verified_entries: list[ACLEntry] = []
+        for attempt in range(max_attempts):
+            verified_entries = await get_acl(hass, node_id)
+
+            if _acl_entry_exists(
+                verified_entries, source_node_id, target_endpoint_id, cluster_id
+            ):
+                _LOGGER.info(
+                    "add_acl_entry: Verified ACL entry persisted on node %s (%d total entries) after %d attempt(s)",
+                    node_id,
+                    len(verified_entries),
+                    attempt + 1,
+                )
+                # Fire success event
+                hass.bus.async_fire(
+                    EVENT_ACL_PROGRESS,
+                    {
+                        "target_node_id": node_id,
+                        "source_node_id": source_node_id,
+                        "status": "success",
+                        "attempt": attempt + 1,
+                        "max_attempts": max_attempts,
+                        "message": "ACL verified successfully",
+                    },
+                )
+                return ACLProvisioningResult(
+                    success=True,
+                    message=f"Successfully added ACL entry ({len(verified_entries)} total)",
+                    acl_entries_count=len(verified_entries),
+                )
+
+            # Entry not found yet, wait and retry
+            if attempt < max_attempts - 1:
+                elapsed = (attempt + 1) * ACL_VERIFY_INTERVAL
+                remaining = ACL_VERIFY_TIMEOUT - elapsed
+                _LOGGER.debug(
+                    "add_acl_entry: ACL entry not found on attempt %d/%d for node %s, retrying in %ds...",
+                    attempt + 1,
+                    max_attempts,
+                    node_id,
+                    ACL_VERIFY_INTERVAL,
+                )
+                # Fire retry progress event
+                hass.bus.async_fire(
+                    EVENT_ACL_PROGRESS,
+                    {
+                        "target_node_id": node_id,
+                        "source_node_id": source_node_id,
+                        "status": "retrying",
+                        "attempt": attempt + 1,
+                        "max_attempts": max_attempts,
+                        "elapsed_seconds": elapsed,
+                        "remaining_seconds": remaining,
+                        "message": f"Waiting for device to process ACL... ({remaining}s remaining)",
+                    },
+                )
+                await asyncio.sleep(ACL_VERIFY_INTERVAL)
+
+        # Exhausted all attempts
+        _LOGGER.error(
+            "add_acl_entry: VERIFICATION FAILED - ACL entry not found after %d seconds! "
+            "source_node=%s, target_node=%s, endpoint=%s, cluster=0x%04X. "
+            "Device may have rejected the entry silently.",
+            ACL_VERIFY_TIMEOUT,
+            source_node_id,
+            node_id,
+            target_endpoint_id,
+            cluster_id,
+        )
+        # Fire failure event
+        hass.bus.async_fire(
+            EVENT_ACL_PROGRESS,
+            {
+                "target_node_id": node_id,
+                "source_node_id": source_node_id,
+                "status": "failed",
+                "attempt": max_attempts,
+                "max_attempts": max_attempts,
+                "message": f"ACL verification failed after {ACL_VERIFY_TIMEOUT}s",
+            },
         )
         return ACLProvisioningResult(
-            success=True,
-            message=f"Successfully added ACL entry ({len(verified_entries)} total)",
+            success=False,
+            message=f"ACL write appeared to succeed but entry not found on device after {ACL_VERIFY_TIMEOUT}s. "
+            "The device may have rejected the entry.",
             acl_entries_count=len(verified_entries),
+            error_type=OperationErrorType.DEVICE_REJECTED,
         )
 
     except Exception as err:
@@ -2856,8 +2935,6 @@ async def create_binding(
             _LOGGER.info("create_binding: Verifying binding was written to device...")
 
             # Small delay to allow device to process
-            import asyncio
-
             await asyncio.sleep(0.2)
 
             # Read back bindings directly from device

--- a/frontend/src/components/wizard/binding-wizard.test.ts
+++ b/frontend/src/components/wizard/binding-wizard.test.ts
@@ -558,4 +558,190 @@ describe("BindingWizard", () => {
       expect(cancelBtn?.textContent?.trim()).toBe("Done");
     });
   });
+
+  describe("ACL progress display", () => {
+    it("should show progress container when ACL is in progress", async () => {
+      element = await fixture<BindingWizard>(html`
+        <matter-binding-wizard
+          .open=${true}
+          .wizardState=${createWizardState({
+            currentStep: "acl",
+            aclInProgress: true,
+          })}
+        ></matter-binding-wizard>
+      `);
+
+      await elementUpdated(element);
+
+      const progressContainer = queryShadow(element, ".acl-progress-container");
+      expect(progressContainer).toBeTruthy();
+    });
+
+    it("should show default message when no progress events received", async () => {
+      element = await fixture<BindingWizard>(html`
+        <matter-binding-wizard
+          .open=${true}
+          .wizardState=${createWizardState({
+            currentStep: "acl",
+            aclInProgress: true,
+          })}
+        ></matter-binding-wizard>
+      `);
+
+      await elementUpdated(element);
+
+      const message = queryShadow(element, ".acl-progress-message");
+      expect(message?.textContent).toContain("Setting permissions on");
+      expect(message?.textContent).toContain("30 seconds");
+    });
+
+    it("should show indeterminate progress bar before first event", async () => {
+      element = await fixture<BindingWizard>(html`
+        <matter-binding-wizard
+          .open=${true}
+          .wizardState=${createWizardState({
+            currentStep: "acl",
+            aclInProgress: true,
+          })}
+        ></matter-binding-wizard>
+      `);
+
+      await elementUpdated(element);
+
+      const progressBar = queryShadow(element, ".acl-progress-bar.indeterminate");
+      expect(progressBar).toBeTruthy();
+    });
+
+    it("should show progress message from event", async () => {
+      element = await fixture<BindingWizard>(html`
+        <matter-binding-wizard
+          .open=${true}
+          .wizardState=${createWizardState({
+            currentStep: "acl",
+            aclInProgress: true,
+            aclProgress: {
+              target_node_id: 2,
+              source_node_id: 1,
+              status: "retrying",
+              attempt: 3,
+              max_attempts: 15,
+              elapsed_seconds: 6,
+              remaining_seconds: 24,
+              message: "Waiting for device to process ACL... (24s remaining)",
+            },
+          })}
+        ></matter-binding-wizard>
+      `);
+
+      await elementUpdated(element);
+
+      const message = queryShadow(element, ".acl-progress-message");
+      expect(message?.textContent).toContain("Waiting for device");
+      expect(message?.textContent).toContain("24s remaining");
+    });
+
+    it("should show determinate progress bar with correct width", async () => {
+      element = await fixture<BindingWizard>(html`
+        <matter-binding-wizard
+          .open=${true}
+          .wizardState=${createWizardState({
+            currentStep: "acl",
+            aclInProgress: true,
+            aclProgress: {
+              target_node_id: 2,
+              source_node_id: 1,
+              status: "retrying",
+              attempt: 5,
+              max_attempts: 10,
+              message: "Waiting...",
+            },
+          })}
+        ></matter-binding-wizard>
+      `);
+
+      await elementUpdated(element);
+
+      const progressBar = queryShadow(element, ".acl-progress-bar:not(.indeterminate)") as HTMLElement;
+      expect(progressBar).toBeTruthy();
+      // 5/10 = 50%
+      expect(progressBar?.style.width).toBe("50%");
+    });
+
+    it("should show attempt counter in progress stats", async () => {
+      element = await fixture<BindingWizard>(html`
+        <matter-binding-wizard
+          .open=${true}
+          .wizardState=${createWizardState({
+            currentStep: "acl",
+            aclInProgress: true,
+            aclProgress: {
+              target_node_id: 2,
+              source_node_id: 1,
+              status: "retrying",
+              attempt: 7,
+              max_attempts: 15,
+              message: "Waiting...",
+            },
+          })}
+        ></matter-binding-wizard>
+      `);
+
+      await elementUpdated(element);
+
+      const attemptStat = queryShadow(element, ".acl-progress-attempt");
+      // attempt is 0-indexed in state, displayed as 1-indexed
+      expect(attemptStat?.textContent).toContain("Attempt 8 of 15");
+    });
+
+    it("should show remaining time when available", async () => {
+      element = await fixture<BindingWizard>(html`
+        <matter-binding-wizard
+          .open=${true}
+          .wizardState=${createWizardState({
+            currentStep: "acl",
+            aclInProgress: true,
+            aclProgress: {
+              target_node_id: 2,
+              source_node_id: 1,
+              status: "retrying",
+              attempt: 3,
+              max_attempts: 15,
+              remaining_seconds: 20,
+              message: "Waiting...",
+            },
+          })}
+        ></matter-binding-wizard>
+      `);
+
+      await elementUpdated(element);
+
+      const stats = queryShadow(element, ".acl-progress-stats");
+      expect(stats?.textContent).toContain("20s remaining");
+    });
+
+    it("should not show progress container after ACL completes", async () => {
+      element = await fixture<BindingWizard>(html`
+        <matter-binding-wizard
+          .open=${true}
+          .wizardState=${createWizardState({
+            currentStep: "acl",
+            aclInProgress: false,
+            aclResult: {
+              success: true,
+              message: "ACL provisioned successfully",
+              acl_entries_count: 2,
+            },
+          })}
+        ></matter-binding-wizard>
+      `);
+
+      await elementUpdated(element);
+
+      const progressContainer = queryShadow(element, ".acl-progress-container");
+      expect(progressContainer).toBeFalsy();
+
+      const result = queryShadow(element, ".wizard-result.success");
+      expect(result).toBeTruthy();
+    });
+  });
 });

--- a/frontend/src/components/wizard/binding-wizard.ts
+++ b/frontend/src/components/wizard/binding-wizard.ts
@@ -186,6 +186,65 @@ export class BindingWizard extends LitElement {
         color: var(--success-color, #4caf50);
         font-weight: 500;
       }
+
+      /* ACL Progress styles */
+      .acl-progress-container {
+        margin-top: 16px;
+        padding: 16px;
+        background: var(--secondary-background-color);
+        border-radius: 8px;
+      }
+
+      .acl-progress-message {
+        font-size: 14px;
+        color: var(--primary-text-color);
+        margin-bottom: 12px;
+        text-align: center;
+      }
+
+      .acl-progress-bar-container {
+        position: relative;
+        height: 8px;
+        background: var(--divider-color, #e0e0e0);
+        border-radius: 4px;
+        overflow: hidden;
+      }
+
+      .acl-progress-bar {
+        height: 100%;
+        background: var(--primary-color);
+        border-radius: 4px;
+        transition: width 0.3s ease;
+      }
+
+      .acl-progress-bar.indeterminate {
+        width: 30%;
+        animation: indeterminate 1.5s infinite ease-in-out;
+      }
+
+      @keyframes indeterminate {
+        0% {
+          transform: translateX(-100%);
+        }
+        50% {
+          transform: translateX(200%);
+        }
+        100% {
+          transform: translateX(-100%);
+        }
+      }
+
+      .acl-progress-stats {
+        display: flex;
+        justify-content: space-between;
+        margin-top: 8px;
+        font-size: 12px;
+        color: var(--secondary-text-color);
+      }
+
+      .acl-progress-attempt {
+        font-weight: 500;
+      }
     `,
   ];
 
@@ -384,8 +443,33 @@ export class BindingWizard extends LitElement {
 
       ${wizard.aclInProgress
         ? html`
-            <div class="wizard-progress-note">
-              Provisioning ACL on ${wizard.targetNode.name}... This may take a few seconds.
+            <div class="acl-progress-container">
+              <div class="acl-progress-message">
+                ${wizard.aclProgress?.message ||
+                  `Setting permissions on ${wizard.targetNode.name}... This may take up to 30 seconds.`}
+              </div>
+              <div class="acl-progress-bar-container">
+                ${wizard.aclProgress && wizard.aclProgress.max_attempts > 0
+                  ? html`
+                      <div
+                        class="acl-progress-bar"
+                        style="width: ${Math.round((wizard.aclProgress.attempt / wizard.aclProgress.max_attempts) * 100)}%"
+                      ></div>
+                    `
+                  : html`<div class="acl-progress-bar indeterminate"></div>`}
+              </div>
+              ${wizard.aclProgress
+                ? html`
+                    <div class="acl-progress-stats">
+                      <span class="acl-progress-attempt">
+                        Attempt ${wizard.aclProgress.attempt + 1} of ${wizard.aclProgress.max_attempts}
+                      </span>
+                      ${wizard.aclProgress.remaining_seconds !== undefined
+                        ? html`<span>${wizard.aclProgress.remaining_seconds}s remaining</span>`
+                        : nothing}
+                    </div>
+                  `
+                : nothing}
             </div>
           `
         : nothing}

--- a/frontend/src/matter-binding-panel.ts
+++ b/frontend/src/matter-binding-panel.ts
@@ -21,8 +21,9 @@ import type {
   ProvisionACLForBindingsResponse,
   OperationProgressState,
   OperationStep,
+  ACLProgressEvent,
 } from "./types";
-import { CLUSTER_NAMES, CLUSTER_ON_OFF, getClusterName, getDeviceTypeName, getClusterBindingDescription, AUTOMATION_TEMPLATES, EVE_CLUSTER_ID, isProprietaryCluster, getClusterInfo, hasThermostatSchedule } from "./types";
+import { CLUSTER_NAMES, CLUSTER_ON_OFF, getClusterName, getDeviceTypeName, getClusterBindingDescription, AUTOMATION_TEMPLATES, EVE_CLUSTER_ID, isProprietaryCluster, getClusterInfo, hasThermostatSchedule, EVENT_ACL_PROGRESS } from "./types";
 import { findMatchingDevice, type DeviceDefinition } from "./device-registry";
 import "./thermostat-schedule-editor";
 import { computeBindingRecommendations } from "./recommendation-logic";
@@ -2075,7 +2076,29 @@ export class MatterBindingPanel extends LitElement {
 
     const { sourceNode, targetNode, targetEndpoint, clusterId } = this._bindingWizard;
 
-    this._bindingWizard = { ...this._bindingWizard, aclInProgress: true };
+    this._bindingWizard = { ...this._bindingWizard, aclInProgress: true, aclProgress: undefined };
+
+    // Subscribe to ACL progress events to show real-time feedback
+    let unsubscribe: (() => void) | null = null;
+    try {
+      unsubscribe = await this.hass.connection.subscribeEvents(
+        (event: unknown) => {
+          const data = (event as { data: ACLProgressEvent }).data;
+          // Only handle events for our current operation
+          if (data.target_node_id === targetNode.node_id &&
+              data.source_node_id === sourceNode.node_id) {
+            this._bindingWizard = {
+              ...this._bindingWizard!,
+              aclProgress: data,
+            };
+          }
+        },
+        EVENT_ACL_PROGRESS
+      );
+    } catch (err) {
+      // Event subscription failed, but we can still proceed without real-time updates
+      console.warn("Failed to subscribe to ACL progress events:", err);
+    }
 
     try {
       const result = await api.provisionACL(
@@ -2090,6 +2113,7 @@ export class MatterBindingPanel extends LitElement {
         ...this._bindingWizard,
         aclResult: result,
         aclInProgress: false,
+        aclProgress: undefined,
       };
 
       // Auto-advance to verify step if ACL succeeded
@@ -2105,7 +2129,13 @@ export class MatterBindingPanel extends LitElement {
           acl_entries_count: 0,
         },
         aclInProgress: false,
+        aclProgress: undefined,
       };
+    } finally {
+      // Clean up event subscription
+      if (unsubscribe) {
+        unsubscribe();
+      }
     }
   }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -190,6 +190,24 @@ export interface ProvisionACLResponse {
   error_type?: OperationErrorType;
 }
 
+// ACL progress event (fired during polling verification)
+export type ACLProgressStatus = "verifying" | "retrying" | "success" | "failed";
+
+export interface ACLProgressEvent {
+  target_node_id: number;
+  source_node_id: number;
+  status: ACLProgressStatus;
+  attempt: number;
+  max_attempts: number;
+  timeout_seconds?: number;
+  elapsed_seconds?: number;
+  remaining_seconds?: number;
+  message: string;
+}
+
+// Event name constant
+export const EVENT_ACL_PROGRESS = "matter_binding_helper_acl_progress";
+
 export interface ProvisionACLForBindingsResponse {
   success: boolean;
   results: Array<{
@@ -222,6 +240,8 @@ export interface BindingWizardState {
   bindingInProgress: boolean;
   aclInProgress: boolean;
   verifyInProgress: boolean;
+  // ACL progress tracking (updated via events during polling)
+  aclProgress?: ACLProgressEvent;
 }
 
 // Operation progress types for blocking dialogs


### PR DESCRIPTION
## Summary

When creating a binding, the ACL verification step now polls the device for up to 30 seconds instead of failing immediately if the entry isn't found on the first read. This handles devices that take time to process ACL writes.

### Changes

**Backend:**
- Add `EVENT_ACL_PROGRESS` event and `ACL_VERIFY_TIMEOUT`/`ACL_VERIFY_INTERVAL` constants
- Update `add_acl_entry()` to poll with 2-second intervals for up to 30 seconds
- Fire progress events during polling with status, attempt count, and remaining time

**Frontend:**
- Add `ACLProgressEvent` type and update `BindingWizardState` to track progress
- Subscribe to progress events during ACL provisioning in wizard
- Display progress bar with percentage, attempt counter, and remaining time
- Show dynamic messages from backend events
- Fallback to indeterminate (animated) progress bar before first event arrives

### User Experience

During ACL provisioning, users now see:
1. Initial message: "Setting permissions on [device]... This may take up to 30 seconds."
2. Progress bar that fills as attempts progress
3. Dynamic updates like "Waiting for device to process ACL... (24s remaining)"
4. Clear attempt counter showing progress through retries (e.g., "Attempt 3 of 15")

## Test plan

- [x] All 307 frontend tests pass (8 new tests for ACL progress display)
- [x] All 24 Python integration tests pass
- [x] Linting passes
- [ ] Manual testing with real Matter devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ACL provisioning now displays real-time progress feedback with a visual progress bar, attempt counter, and remaining time during verification
  * Enhanced verification process with automatic retry attempts and status messaging (verifying, retrying, success, failed) to improve reliability and provide clear feedback

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->