### PR TITLE
perf: defer binding fetches during startup to background

### DIFF
--- a/custom_components/matter_binding_helper/sensor.py
+++ b/custom_components/matter_binding_helper/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -112,27 +113,63 @@ class MatterBindingCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=timedelta(seconds=SCAN_INTERVAL_SECONDS),
         )
         self.config_entry = config_entry
+        self._initial_load = True  # Track first load to defer binding fetch
 
     async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch data from Matter server."""
+        """Fetch data from Matter server.
+
+        On initial load, only fetches nodes to speed up startup.
+        Bindings are fetched on subsequent updates (after ~30s).
+        """
         data: dict[str, Any] = {
             "nodes": [],
             "bindings": {},  # Key: (node_id, endpoint_id), Value: list of bindings
         }
 
         try:
-            # Get all nodes
+            # Always fetch nodes - needed for entity creation
             nodes = await get_nodes(self.hass)
             data["nodes"] = nodes
 
-            # Fetch bindings for each endpoint with binding cluster
+            # Skip bindings on initial load to speed up HA startup
+            # Entities will show "0 bindings" until first regular update
+            if self._initial_load:
+                self._initial_load = False
+                _LOGGER.debug(
+                    "Initial load: %d nodes fetched, deferring binding fetch to background",
+                    len(nodes),
+                )
+                return data
+
+            # Fetch bindings in parallel for better performance
+            binding_tasks: list[asyncio.Task[list]] = []
+            binding_keys: list[tuple[int, int]] = []
+
             for node in nodes:
                 node_id = node["node_id"]
                 for endpoint in node.get("endpoints", []):
                     endpoint_id = endpoint["endpoint_id"]
                     if endpoint.get("has_binding_cluster") and endpoint_id != 0:
-                        bindings = await get_bindings(self.hass, node_id, endpoint_id)
-                        data["bindings"][(node_id, endpoint_id)] = bindings
+                        binding_tasks.append(
+                            asyncio.create_task(
+                                get_bindings(self.hass, node_id, endpoint_id)
+                            )
+                        )
+                        binding_keys.append((node_id, endpoint_id))
+
+            if binding_tasks:
+                results = await asyncio.gather(*binding_tasks, return_exceptions=True)
+                for key, result in zip(binding_keys, results):
+                    if isinstance(result, Exception):
+                        _LOGGER.warning(
+                            "Failed to fetch bindings for node %d endpoint %d: %s",
+                            key[0],
+                            key[1],
+                            result,
+                        )
+                        data["bindings"][key] = []
+                    else:
+                        data["bindings"][key] = result
 
             _LOGGER.debug(
                 "Coordinator update: %d nodes, %d binding endpoints",


### PR DESCRIPTION
## Summary
- Defer binding fetches on initial coordinator load to speed up HA startup
- Fetch bindings in parallel (using `asyncio.gather`) on subsequent updates (~30s interval)
- Add per-endpoint error handling for binding fetch failures

## Problem
The integration was significantly slowing down Home Assistant startup times. The root cause was that `async_config_entry_first_refresh()` blocks startup until the coordinator's `_async_update_data()` completes, and that method was sequentially fetching bindings for every node/endpoint with a binding cluster.

With cache misses, 10 nodes × 5 endpoints = 50 sequential network calls blocking startup.

## Solution
Entity creation only needs **node data** - binding data is only accessed later via `_get_bindings()`. By deferring binding fetches to the first regular update cycle:
- **Startup**: Near-instant – only fetches nodes
- **After ~30s**: Bindings fetched in parallel during first coordinator update
- **Tradeoff**: Sensors show "0 bindings" for ~30s, then display accurate counts

## Test plan
- [ ] Run `make dev-full` to start HA
- [ ] Check startup logs with `make logs-component`
- [ ] Verify "Initial load: X nodes fetched, deferring binding fetch to background" appears quickly
- [ ] Verify bindings populate after ~30s (first regular update)
- [ ] Confirm no errors in logs during binding fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Accelerated startup speed by deferring non-critical binding data fetches on initial load.
  * Enhanced performance of binding data retrieval through parallelized processing.
  * Strengthened error resilience with per-endpoint error handling and fallback mechanisms for failed binding fetches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->