### PR TITLE
fix: handle None cluster_id in bindings (fixes #110)

### DIFF
--- a/custom_components/matter_binding_helper/matter/bindings.py
+++ b/custom_components/matter_binding_helper/matter/bindings.py
@@ -92,7 +92,7 @@ async def get_bindings(
                 entry = BindingEntry(
                     node_id=node_id,
                     endpoint_id=endpoint_id,
-                    cluster_id=binding.get("Cluster", 0),
+                    cluster_id=binding.get("Cluster"),  # Can be None (any cluster)
                     target_node_id=binding.get("Node"),
                     target_endpoint_id=binding.get("Endpoint"),
                     target_group_id=binding.get("Group"),
@@ -286,20 +286,19 @@ def _parse_binding_value(
         )
 
         # Extract binding fields - handle various formats
-        cluster_id = 0
+        # cluster_id can be None (meaning "any cluster" per Matter spec)
+        cluster_id: int | None = None
         target_node = None
         target_endpoint = None
         target_group = None
 
         if isinstance(binding, dict):
             # Dict format - try multiple key naming conventions
-            cluster_id = (
-                binding.get("Cluster")
-                or binding.get("cluster")
-                or binding.get("ClusterId")
-                or binding.get("clusterId")
-                or 0
-            )
+            # Use explicit None check to allow cluster_id=0 (which is falsy but valid)
+            for key in ("Cluster", "cluster", "ClusterId", "clusterId"):
+                if key in binding and binding[key] is not None:
+                    cluster_id = binding[key]
+                    break
             target_node = (
                 binding.get("Node")
                 or binding.get("node")
@@ -320,7 +319,8 @@ def _parse_binding_value(
             )
         elif hasattr(binding, "cluster"):
             # Object with snake_case attributes
-            cluster_id = getattr(binding, "cluster", 0)
+            # cluster can be None (meaning "any cluster" per Matter spec)
+            cluster_id = getattr(binding, "cluster", None)
             target_node = getattr(binding, "node", None)
             target_endpoint = getattr(binding, "endpoint", None)
             target_group = getattr(binding, "group", None)
@@ -952,12 +952,17 @@ async def provision_acls_for_existing_bindings(
             )
             continue
 
+        cluster_label = (
+            f"0x{binding.cluster_id:04X}"
+            if binding.cluster_id is not None
+            else "Any Cluster"
+        )
         _LOGGER.info(
             "provision_acls_for_existing_bindings: Processing binding -> "
-            "node %s ep %s cluster 0x%04X",
+            "node %s ep %s cluster %s",
             binding.target_node_id,
             binding.target_endpoint_id,
-            binding.cluster_id,
+            cluster_label,
         )
 
         result = await provision_acl_for_binding(

--- a/custom_components/matter_binding_helper/matter/models.py
+++ b/custom_components/matter_binding_helper/matter/models.py
@@ -36,7 +36,7 @@ class BindingEntry:
 
     node_id: int
     endpoint_id: int
-    cluster_id: int
+    cluster_id: int | None = None
     target_node_id: int | None = None
     target_endpoint_id: int | None = None
     target_group_id: int | None = None

--- a/custom_components/matter_binding_helper/sensor.py
+++ b/custom_components/matter_binding_helper/sensor.py
@@ -325,8 +325,10 @@ class MatterBindingSensor(CoordinatorEntity[MatterBindingCoordinator], SensorEnt
 
         return f"Node {node_id}"
 
-    def _get_cluster_name(self, cluster_id: int) -> str:
+    def _get_cluster_name(self, cluster_id: int | None) -> str:
         """Get a human-readable cluster name."""
+        if cluster_id is None:
+            return "Any Cluster"
         # Common Matter cluster names
         cluster_names = {
             0x0003: "Identify",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -134,14 +134,14 @@ export async function provisionACL(
   targetNodeId: number,
   targetEndpointId: number,
   sourceNodeId: number,
-  clusterId: number
+  clusterId: number | null  // null means "any cluster" per Matter spec
 ): Promise<ProvisionACLResponse> {
   return hass.callWS({
     type: `${DOMAIN}/provision_acl`,
     target_node_id: targetNodeId,
     target_endpoint_id: targetEndpointId,
     source_node_id: sourceNodeId,
-    cluster_id: clusterId,
+    ...(clusterId !== null && { cluster_id: clusterId }),
   });
 }
 
@@ -158,15 +158,15 @@ export async function removeACL(
   hass: HomeAssistant,
   targetNodeId: number,
   sourceNodeId: number,
-  targetEndpointId?: number,
-  clusterId?: number
+  targetEndpointId?: number | null,
+  clusterId?: number | null  // null/undefined means "any cluster"
 ): Promise<ProvisionACLResponse> {
   return hass.callWS({
     type: `${DOMAIN}/remove_acl`,
     target_node_id: targetNodeId,
     source_node_id: sourceNodeId,
-    ...(targetEndpointId !== undefined && { target_endpoint_id: targetEndpointId }),
-    ...(clusterId !== undefined && { cluster_id: clusterId }),
+    ...(targetEndpointId != null && { target_endpoint_id: targetEndpointId }),
+    ...(clusterId != null && { cluster_id: clusterId }),
   });
 }
 

--- a/frontend/src/matter-binding-panel.ts
+++ b/frontend/src/matter-binding-panel.ts
@@ -725,7 +725,10 @@ export class MatterBindingPanel extends LitElement {
     return node?.ha_device_id;
   }
 
-  private _getClusterName(clusterId: number): string {
+  private _getClusterName(clusterId: number | null): string {
+    if (clusterId === null) {
+      return "Any Cluster";
+    }
     return CLUSTER_NAMES[clusterId] || `Cluster 0x${clusterId.toString(16)}`;
   }
 
@@ -1572,9 +1575,10 @@ export class MatterBindingPanel extends LitElement {
 
     // Determine required privilege based on cluster type
     // Control clusters need Operate (3), sensor clusters need View (1)
+    // "Any cluster" bindings (cluster_id=null) require Operate since they could control anything
     const clusterId = binding.cluster_id;
     const controlClusters = [0x0006, 0x0008, 0x0300, 0x0201, 0x0202]; // On/Off, Level, Color, Thermostat, Fan
-    const requiredPrivilege = controlClusters.includes(clusterId) ? 3 : 1;
+    const requiredPrivilege = clusterId === null || controlClusters.includes(clusterId) ? 3 : 1;
     const requiredPrivilegeName = requiredPrivilege === 3 ? "Operate" : "View";
 
     // Find a matching ACL entry

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -76,7 +76,7 @@ export interface DeviceType {
 export interface Binding {
   node_id: number;
   endpoint_id: number;
-  cluster_id: number;
+  cluster_id: number | null;  // Can be null for "any cluster" bindings (per Matter spec)
   target_node_id: number | null;
   target_endpoint_id: number | null;
   target_group_id: number | null;
@@ -420,7 +420,11 @@ import { getEnhancedClusterName, getClusterInfo, isProprietaryCluster } from "./
 export { getEnhancedClusterName, getClusterInfo, isProprietaryCluster };
 
 // Helper functions
-export function getClusterName(clusterId: number): string {
+export function getClusterName(clusterId: number | null): string {
+  // Handle null cluster_id (means "any cluster" per Matter spec)
+  if (clusterId === null) {
+    return "Any Cluster";
+  }
   // First check standard cluster names
   if (CLUSTER_NAMES[clusterId]) {
     return CLUSTER_NAMES[clusterId];
@@ -433,7 +437,14 @@ export function getDeviceTypeName(deviceTypeId: number): string {
   return DEVICE_TYPE_NAMES[deviceTypeId] || `Type ${deviceTypeId}`;
 }
 
-export function getClusterBindingDescription(clusterId: number): { action: string; dataType: string } {
+export function getClusterBindingDescription(clusterId: number | null): { action: string; dataType: string } {
+  // Handle null cluster_id (means "any cluster" per Matter spec)
+  if (clusterId === null) {
+    return {
+      action: "send all commands to",
+      dataType: "all supported commands",
+    };
+  }
   return CLUSTER_BINDING_DESCRIPTIONS[clusterId] || {
     action: "communicate with",
     dataType: `${getClusterName(clusterId)} data`,

--- a/tests/unit/test_bindings_parsing.py
+++ b/tests/unit/test_bindings_parsing.py
@@ -1,0 +1,145 @@
+"""Unit tests for binding parsing with None cluster_id (Issue #110).
+
+Tests that bindings with cluster_id=None (any cluster per Matter spec)
+are handled correctly without causing TypeError.
+"""
+
+import pytest
+
+from custom_components.matter_binding_helper.matter.models import BindingEntry
+from custom_components.matter_binding_helper.matter.bindings import (
+    _parse_binding_value,
+)
+
+
+class TestParseBindingValueNoneCluster:
+    """Tests for _parse_binding_value with None cluster_id."""
+
+    def test_parse_dict_binding_with_none_cluster(self):
+        """Test parsing dict binding where Cluster key exists but is None."""
+        binding_value = [
+            {
+                "Node": 5,
+                "Endpoint": 1,
+                "Cluster": None,  # Explicitly None
+            }
+        ]
+        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+
+        assert len(result) == 1
+        assert result[0].cluster_id is None
+        assert result[0].target_node_id == 5
+        assert result[0].target_endpoint_id == 1
+
+    def test_parse_dict_binding_without_cluster_key(self):
+        """Test parsing dict binding where Cluster key is missing entirely."""
+        binding_value = [
+            {
+                "Node": 5,
+                "Endpoint": 1,
+                # No Cluster key at all
+            }
+        ]
+        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+
+        assert len(result) == 1
+        assert result[0].cluster_id is None
+        assert result[0].target_node_id == 5
+
+    def test_parse_dict_binding_with_cluster_zero(self):
+        """Test parsing dict binding with cluster_id=0 (valid cluster ID)."""
+        binding_value = [
+            {
+                "Node": 5,
+                "Endpoint": 1,
+                "Cluster": 0,  # 0 is falsy but valid
+            }
+        ]
+        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+
+        assert len(result) == 1
+        # Note: 0 is a valid cluster ID, should not be converted to None
+        # However, with the or-chain fix, we need explicit None check
+        # The current implementation treats 0 as a valid value
+        assert result[0].cluster_id == 0
+
+    def test_parse_dict_binding_with_valid_cluster(self):
+        """Test parsing dict binding with a normal cluster_id."""
+        binding_value = [
+            {
+                "Node": 5,
+                "Endpoint": 1,
+                "Cluster": 6,  # On/Off cluster
+            }
+        ]
+        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+
+        assert len(result) == 1
+        assert result[0].cluster_id == 6
+
+    def test_parse_object_binding_with_none_cluster(self):
+        """Test parsing object binding where cluster attribute is None.
+
+        This reproduces the exact scenario from issue #110 where
+        esp-matter devices return binding objects with cluster=None.
+        """
+
+        class MockBinding:
+            """Mock binding object like from esp-matter device."""
+
+            cluster = None
+            node = 5
+            endpoint = 1
+            group = None
+
+        binding_value = [MockBinding()]
+        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+
+        assert len(result) == 1
+        assert result[0].cluster_id is None
+        assert result[0].target_node_id == 5
+        assert result[0].target_endpoint_id == 1
+
+    def test_parse_object_binding_with_valid_cluster(self):
+        """Test parsing object binding with a normal cluster value."""
+
+        class MockBinding:
+            cluster = 8  # Level Control
+            node = 5
+            endpoint = 1
+            group = None
+
+        binding_value = [MockBinding()]
+        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+
+        assert len(result) == 1
+        assert result[0].cluster_id == 8
+
+    def test_parse_multiple_bindings_mixed_cluster(self):
+        """Test parsing multiple bindings with mixed cluster values."""
+        binding_value = [
+            {"Node": 5, "Endpoint": 1, "Cluster": 6},
+            {"Node": 6, "Endpoint": 1, "Cluster": None},
+            {"Node": 7, "Endpoint": 2},  # No Cluster key
+        ]
+        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+
+        assert len(result) == 3
+        assert result[0].cluster_id == 6
+        assert result[1].cluster_id is None
+        assert result[2].cluster_id is None
+
+    def test_parse_group_binding_with_none_cluster(self):
+        """Test parsing group binding with None cluster."""
+        binding_value = [
+            {
+                "Group": 100,
+                "Cluster": None,
+            }
+        ]
+        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+
+        assert len(result) == 1
+        assert result[0].cluster_id is None
+        assert result[0].target_group_id == 100
+        assert result[0].target_node_id is None

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -102,6 +102,33 @@ class TestBindingEntry:
         assert result["target_group_id"] == 50
         assert result["target_node_id"] is None
 
+    def test_create_binding_with_none_cluster_id(self):
+        """Test creating a binding with cluster_id=None (any cluster).
+
+        Per Matter spec, bindings may omit cluster_id to indicate
+        the binding applies to all applicable clusters.
+        """
+        binding = BindingEntry(
+            node_id=1,
+            endpoint_id=1,
+            target_node_id=2,
+            target_endpoint_id=1,
+        )
+        assert binding.cluster_id is None
+        assert binding.target_node_id == 2
+
+    def test_to_dict_with_none_cluster_id(self):
+        """Test to_dict correctly includes None cluster_id."""
+        binding = BindingEntry(
+            node_id=1,
+            endpoint_id=1,
+            target_node_id=2,
+            target_endpoint_id=1,
+        )
+        result = binding.to_dict()
+        assert result["cluster_id"] is None
+        assert result["target_node_id"] == 2
+
 
 class TestScheduleTransition:
     """Tests for ScheduleTransition dataclass."""


### PR DESCRIPTION
## Summary

- Fix `TypeError: unsupported format string passed to NoneType.__format__` when bindings have `cluster_id=None`
- Per Matter spec, bindings may omit `cluster_id` to indicate the binding applies to all applicable clusters
- Devices like esp-matter return `null` for cluster_id which is spec-conformant

## Changes

### Backend (Python)
- Update `BindingEntry` model to allow `cluster_id: int | None`
- Add `None` check in `_get_cluster_name()` returning "Any Cluster"
- Fix `_parse_binding_value()` to properly propagate `None` values instead of defaulting to `0`
- Add 10 unit tests for `None` cluster_id scenarios

### Frontend (TypeScript)
- Update `Binding` interface: `cluster_id: number | null`
- Update `getClusterName()` and `getClusterBindingDescription()` to handle null
- Update `provisionACL()` and `removeACL()` API functions to accept null cluster_id
- "Any cluster" bindings now display as "Any Cluster" and "send all commands to"

## Test plan

- [x] Run `make lint` and `make format`
- [x] Run Python unit tests: `pytest tests/unit/ -v` (163 tests pass)
- [x] Run frontend tests: `npm test` (320 tests pass)
- [x] Build frontend: `npm run build`
- [ ] Manual test with esp-matter device that reports `cluster_id=null`

Fixes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display and support for "Any Cluster" bindings per Matter spec — bindings without a specific cluster now show as "Any Cluster".

* **Permissions**
  * Bindings marked as "Any Cluster" now require a higher operate-level privilege where applicable, updating ACL checks and messaging.

* **API**
  * Frontend APIs and payloads accept/serialize nullable cluster IDs and omit fields when unspecified.

* **Tests**
  * Added comprehensive unit tests for parsing and model behavior with optional/null cluster IDs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->