### PR TITLE
fix: handle None cluster_id in provision_acls_for_existing_bindings

### DIFF
--- a/custom_components/matter_binding_helper/matter/bindings.py
+++ b/custom_components/matter_binding_helper/matter/bindings.py
@@ -952,6 +952,17 @@ async def provision_acls_for_existing_bindings(
             )
             continue
 
+        if binding.cluster_id is None:
+            # Wildcard bindings (cluster_id=None means "any cluster" per Matter spec)
+            # are intentionally skipped because the ACL provisioning functions
+            # (add_acl_entry, provision_acl_for_binding) don't support wildcard clusters.
+            # TODO: Consider adding wildcard cluster ACL support in the future.
+            _LOGGER.debug(
+                "provision_acls_for_existing_bindings: Skipping wildcard binding "
+                "(cluster_id=None means 'any cluster')"
+            )
+            continue
+
         cluster_label = (
             f"0x{binding.cluster_id:04X}"
             if binding.cluster_id is not None


### PR DESCRIPTION
## Summary
- Adds a guard to skip wildcard bindings (`cluster_id=None`) before calling `provision_acl_for_binding()`
- Prevents `TypeError` when the log statement uses `0x%04X` format with `None` value
- Follows the existing pattern that already skips bindings without `target_endpoint_id`

## Behavioral Note
This **intentionally skips** ACL provisioning for wildcard bindings (`cluster_id=None` means "any cluster" per Matter spec). The current ACL provisioning functions (`add_acl_entry`, `provision_acl_for_binding`) don't support wildcard clusters, so these bindings cannot have ACLs provisioned.

A TODO comment has been added to consider adding wildcard cluster ACL support in the future.

## Test plan
- [x] Run `make lint` to verify no linting errors
- [ ] Verify wildcard bindings are logged and skipped gracefully
- [ ] Verify non-wildcard bindings continue to get ACLs provisioned