### PR TITLE
fix: use config_entries API instead of hass.data to detect Matter integration

### DIFF
--- a/custom_components/matter_binding_helper/__init__.py
+++ b/custom_components/matter_binding_helper/__init__.py
@@ -49,7 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from .const import CONF_DEMO_MODE, DEFAULT_DEMO_MODE
 
     demo_mode = entry.options.get(CONF_DEMO_MODE, DEFAULT_DEMO_MODE)
-    if not demo_mode and MATTER_DOMAIN not in hass.data:
+    if not demo_mode and not hass.config_entries.async_entries(MATTER_DOMAIN):
         _LOGGER.error("Matter integration is not set up")
         return False
 
@@ -106,15 +106,18 @@ async def _async_register_panel(hass: HomeAssistant) -> None:
     # Register the panel serving the frontend
     from homeassistant.components.http import StaticPathConfig
 
-    await hass.http.async_register_static_paths(
-        [
-            StaticPathConfig(
-                url_path="/matter_binding_helper/frontend",
-                path=hass.config.path(f"custom_components/{DOMAIN}/frontend"),
-                cache_headers=False,
-            )
-        ]
-    )
+    try:
+        await hass.http.async_register_static_paths(
+            [
+                StaticPathConfig(
+                    url_path="/matter_binding_helper/frontend",
+                    path=hass.config.path(f"custom_components/{DOMAIN}/frontend"),
+                    cache_headers=False,
+                )
+            ]
+        )
+    except RuntimeError:
+        pass  # Already registered (e.g. on reload)
 
     await panel_custom.async_register_panel(
         hass,

--- a/custom_components/matter_binding_helper/config_flow.py
+++ b/custom_components/matter_binding_helper/config_flow.py
@@ -43,7 +43,7 @@ class MatterBindingHelperConfigFlow(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         # Require Matter integration to be configured
-        if MATTER_DOMAIN not in self.hass.data:
+        if not self.hass.config_entries.async_entries(MATTER_DOMAIN):
             return self.async_abort(reason="matter_not_configured")
 
         if user_input is not None:

--- a/custom_components/matter_binding_helper/matter/client.py
+++ b/custom_components/matter_binding_helper/matter/client.py
@@ -150,23 +150,29 @@ def get_raw_matter_client(hass: HomeAssistant) -> "RealMatterServerClient | None
     except ImportError:
         return None
 
-    if MATTER_DOMAIN not in hass.data:
-        return None
+    # Modern HA: data lives on entry.runtime_data (typed config entry pattern, HA >= ~2024.7)
+    for entry in hass.config_entries.async_entries(MATTER_DOMAIN):
+        runtime_data = getattr(entry, "runtime_data", None)
+        if runtime_data is None:
+            continue
+        # Current HA structure: runtime_data.adapter.matter_client
+        adapter = getattr(runtime_data, "adapter", None)
+        if adapter and hasattr(adapter, "matter_client"):
+            return adapter.matter_client
+        # Possible variant: matter_client directly on runtime_data
+        if hasattr(runtime_data, "matter_client"):
+            return runtime_data.matter_client
 
-    # Get the first Matter entry data
+    # Legacy fallback: hass.data[MATTER_DOMAIN] (HA < ~2024.7)
     matter_data = hass.data.get(MATTER_DOMAIN)
-    if not matter_data:
-        return None
-
-    # Matter stores data by config entry ID
-    for entry_data in matter_data.values():
-        if hasattr(entry_data, "matter_client"):
-            return entry_data.matter_client
-        # Fallback for different HA versions
-        if hasattr(entry_data, "adapter") and hasattr(
-            entry_data.adapter, "matter_client"
-        ):
-            return entry_data.adapter.matter_client
+    if matter_data:
+        for entry_data in matter_data.values():
+            if hasattr(entry_data, "matter_client"):
+                return entry_data.matter_client
+            if hasattr(entry_data, "adapter") and hasattr(
+                entry_data.adapter, "matter_client"
+            ):
+                return entry_data.adapter.matter_client
 
     return None
 


### PR DESCRIPTION
## Summary

Fixes #210 — install fails with `matter_not_configured` on HA 2026.5+.

- The HA Matter integration migrated to the typed config entry pattern (`entry.runtime_data`) in HA >= ~2024.7, so `hass.data["matter"]` is no longer populated. The `MATTER_DOMAIN not in hass.data` check always returned `True`, blocking setup for every non-demo install.
- Replace `hass.data` presence checks with `hass.config_entries.async_entries(MATTER_DOMAIN)` in `config_flow.py` and `__init__.py`
- Update `get_raw_matter_client()` to find the client via `entry.runtime_data.adapter.matter_client`, with a legacy fallback to `hass.data` for HA < ~2024.7
- Guard static path registration against `RuntimeError` on reload (secondary bug exposed once the main fix allowed setup to proceed)

## Test plan

- [ ] Install with Matter integration present — should proceed past setup without `matter_not_configured`
- [ ] Install without Matter integration — should still abort with `matter_not_configured`
- [ ] Reload/restart integration — should not crash with `RuntimeError` on static path re-registration
- [ ] Demo mode still works without Matter present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Matter integration availability detection for better handling during configuration reloads
  * Enhanced setup robustness when Matter integration state changes
  * Added backward compatibility for legacy data structures

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/ha-matter-binding-helper/pull/213)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->