### PR TITLE
feat(groups): honesty gate + group constants foundation (1/N)

### DIFF
--- a/custom_components/matter_binding_helper/api.py
+++ b/custom_components/matter_binding_helper/api.py
@@ -1259,11 +1259,13 @@ async def ws_create_group(
     msg: dict[str, Any],
 ) -> None:
     """Create a new Matter group."""
-    success = await matter_client.create_group(hass, msg["group_id"], msg["name"])
-    if success:
+    result = await matter_client.create_group(hass, msg["group_id"], msg["name"])
+    if result.success:
         connection.send_result(msg["id"], {"success": True})
     else:
-        connection.send_error(msg["id"], "create_failed", "Failed to create group")
+        connection.send_error(
+            msg["id"], result.error_code or "create_failed", result.message
+        )
 
 
 @websocket_api.websocket_command(
@@ -1279,11 +1281,13 @@ async def ws_delete_group(
     msg: dict[str, Any],
 ) -> None:
     """Delete a Matter group."""
-    success = await matter_client.delete_group(hass, msg["group_id"])
-    if success:
+    result = await matter_client.delete_group(hass, msg["group_id"])
+    if result.success:
         connection.send_result(msg["id"], {"success": True})
     else:
-        connection.send_error(msg["id"], "delete_failed", "Failed to delete group")
+        connection.send_error(
+            msg["id"], result.error_code or "delete_failed", result.message
+        )
 
 
 @websocket_api.websocket_command(
@@ -1301,13 +1305,15 @@ async def ws_add_to_group(
     msg: dict[str, Any],
 ) -> None:
     """Add an endpoint to a group."""
-    success = await matter_client.add_to_group(
+    result = await matter_client.add_to_group(
         hass, msg["group_id"], msg["node_id"], msg["endpoint_id"]
     )
-    if success:
+    if result.success:
         connection.send_result(msg["id"], {"success": True})
     else:
-        connection.send_error(msg["id"], "add_failed", "Failed to add to group")
+        connection.send_error(
+            msg["id"], result.error_code or "add_failed", result.message
+        )
 
 
 @websocket_api.websocket_command(
@@ -1325,13 +1331,15 @@ async def ws_remove_from_group(
     msg: dict[str, Any],
 ) -> None:
     """Remove an endpoint from a group."""
-    success = await matter_client.remove_from_group(
+    result = await matter_client.remove_from_group(
         hass, msg["group_id"], msg["node_id"], msg["endpoint_id"]
     )
-    if success:
+    if result.success:
         connection.send_result(msg["id"], {"success": True})
     else:
-        connection.send_error(msg["id"], "remove_failed", "Failed to remove from group")
+        connection.send_error(
+            msg["id"], result.error_code or "remove_failed", result.message
+        )
 
 
 # =============================================================================

--- a/custom_components/matter_binding_helper/const.py
+++ b/custom_components/matter_binding_helper/const.py
@@ -40,6 +40,8 @@ CLUSTER_SCENES = 0x0005
 CLUSTER_DESCRIPTOR = 0x001D  # Descriptor cluster
 CLUSTER_THERMOSTAT = 0x0201  # Thermostat cluster
 CLUSTER_ACCESS_CONTROL = 0x001F  # Access Control cluster
+CLUSTER_GROUPS = 0x0004  # Groups cluster (per-endpoint group membership)
+CLUSTER_GROUP_KEY_MANAGEMENT = 0x003F  # Group Key Management cluster (root endpoint)
 
 # WebSocket commands for thermostat schedules
 WS_TYPE_GET_SCHEDULE = f"{DOMAIN}/get_schedule"
@@ -87,6 +89,17 @@ ACL_AUTH_MODE_GROUP = 3  # Group messaging
 EVENT_ACL_PROGRESS = f"{DOMAIN}_acl_progress"
 ACL_VERIFY_TIMEOUT = 30  # seconds
 ACL_VERIFY_INTERVAL = 2  # seconds
+
+# Group Key Management
+# Group key set 0 is the reserved Identity Protection Key (IPK); application
+# group key sets are allocated from this base upward.
+GROUP_KEY_SET_BASE = 0x0100
+GROUP_KEY_SECURITY_POLICY_TRUST_FIRST = 0  # GroupKeySecurityPolicyEnum.kTrustFirst
+
+# Group provisioning progress events (mirrors ACL provisioning)
+EVENT_GROUP_PROGRESS = f"{DOMAIN}_group_progress"
+GROUP_VERIFY_TIMEOUT = 30  # seconds
+GROUP_VERIFY_INTERVAL = 2  # seconds
 
 # Cluster-to-privilege mapping for bindings
 # Maps cluster IDs to the minimum privilege required to operate on them

--- a/custom_components/matter_binding_helper/matter/groups.py
+++ b/custom_components/matter_binding_helper/matter/groups.py
@@ -1,7 +1,9 @@
 """Group operations for Matter devices.
 
-Note: These are placeholder stubs. Actual implementation depends on
-how python-matter-server exposes group management at the fabric level.
+Groupcast is implemented incrementally (see the group provisioning plan). Until
+the real Groups cluster + Group Key Management path lands, the mutating
+operations return an explicit "not supported" result instead of silently failing,
+so the UI can tell the user the truth rather than appearing to succeed/no-op.
 """
 
 from __future__ import annotations
@@ -10,49 +12,73 @@ import logging
 
 from homeassistant.core import HomeAssistant
 
-from .models import GroupEntry
+from .models import GroupEntry, GroupOperationResult
 
 _LOGGER = logging.getLogger(__name__)
+
+# Stable error code surfaced to the frontend while groupcast is unimplemented.
+GROUP_NOT_SUPPORTED_CODE = "not_supported"
+GROUP_NOT_SUPPORTED_MESSAGE = (
+    "Matter group management is not implemented yet. Group creation, membership "
+    "and groupcast bindings are coming in a future release."
+)
+
+
+def _not_supported() -> GroupOperationResult:
+    """Return the standard 'not yet supported' result for group mutations."""
+    return GroupOperationResult(
+        success=False,
+        message=GROUP_NOT_SUPPORTED_MESSAGE,
+        error_code=GROUP_NOT_SUPPORTED_CODE,
+    )
 
 
 async def get_groups(hass: HomeAssistant) -> list[GroupEntry]:
     """Get all Matter groups.
 
-    Groups in Matter are managed at the fabric level.
-    This is a placeholder - actual implementation depends on
-    how python-matter-server exposes group management.
+    Returns an empty list until group support is implemented. Listing nothing is
+    honest (there are no managed groups yet); only the mutating operations report
+    the unsupported state.
     """
-    _LOGGER.debug("Getting Matter groups")
+    _LOGGER.debug("get_groups: group support not implemented yet, returning []")
     return []
 
 
-async def create_group(hass: HomeAssistant, group_id: int, name: str) -> bool:
+async def create_group(
+    hass: HomeAssistant, group_id: int, name: str
+) -> GroupOperationResult:
     """Create a new Matter group."""
-    _LOGGER.debug("Creating group %s: %s", group_id, name)
-    return False
+    _LOGGER.debug("create_group: not supported yet (group %s: %s)", group_id, name)
+    return _not_supported()
 
 
-async def delete_group(hass: HomeAssistant, group_id: int) -> bool:
+async def delete_group(hass: HomeAssistant, group_id: int) -> GroupOperationResult:
     """Delete a Matter group."""
-    _LOGGER.debug("Deleting group %s", group_id)
-    return False
+    _LOGGER.debug("delete_group: not supported yet (group %s)", group_id)
+    return _not_supported()
 
 
 async def add_to_group(
     hass: HomeAssistant, group_id: int, node_id: int, endpoint_id: int
-) -> bool:
+) -> GroupOperationResult:
     """Add an endpoint to a group."""
     _LOGGER.debug(
-        "Adding node %s endpoint %s to group %s", node_id, endpoint_id, group_id
+        "add_to_group: not supported yet (node %s endpoint %s -> group %s)",
+        node_id,
+        endpoint_id,
+        group_id,
     )
-    return False
+    return _not_supported()
 
 
 async def remove_from_group(
     hass: HomeAssistant, group_id: int, node_id: int, endpoint_id: int
-) -> bool:
+) -> GroupOperationResult:
     """Remove an endpoint from a group."""
     _LOGGER.debug(
-        "Removing node %s endpoint %s from group %s", node_id, endpoint_id, group_id
+        "remove_from_group: not supported yet (node %s endpoint %s -> group %s)",
+        node_id,
+        endpoint_id,
+        group_id,
     )
-    return False
+    return _not_supported()

--- a/custom_components/matter_binding_helper/matter/models.py
+++ b/custom_components/matter_binding_helper/matter/models.py
@@ -142,6 +142,28 @@ class GroupEntry:
 
 
 @dataclass
+class GroupOperationResult:
+    """Result of a group management operation (create/delete/add/remove member).
+
+    Mirrors ACLProvisioningResult so the WebSocket layer can surface structured
+    success/failure. ``error_code`` is a stable, machine-readable string sent to
+    the frontend (e.g. ``"not_supported"`` while groupcast is unimplemented).
+    """
+
+    success: bool
+    message: str
+    error_code: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "success": self.success,
+            "message": self.message,
+            "error_code": self.error_code,
+        }
+
+
+@dataclass
 class ACLTarget:
     """Represents an ACL target restriction."""
 

--- a/custom_components/matter_binding_helper/matter_client.py
+++ b/custom_components/matter_binding_helper/matter_client.py
@@ -12,7 +12,7 @@ Module structure:
 - matter/bindings.py: Binding CRUD operations
 - matter/acl.py: Access Control List operations
 - matter/thermostat.py: Thermostat schedule operations
-- matter/groups.py: Group operations (stubs)
+- matter/groups.py: Group operations (not yet supported; honesty gate)
 - matter/proprietary.py: Proprietary attribute operations
 - matter/ha_registry.py: Home Assistant registry integration
 - matter/utils.py: Error handling and utilities
@@ -106,7 +106,7 @@ from .matter.thermostat import (
     supports_thermostat_schedule,
 )
 
-# Groups - group operations (stubs)
+# Groups - group operations (not yet supported; honesty gate)
 from .matter.groups import (
     add_to_group,
     create_group,

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -1,0 +1,65 @@
+"""Unit tests for matter/groups.py.
+
+Covers the "honesty gate": until groupcast is implemented, mutating group
+operations must report an explicit unsupported result rather than silently
+no-op'ing, while listing returns an empty list.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from custom_components.matter_binding_helper.matter.groups import (
+    GROUP_NOT_SUPPORTED_CODE,
+    add_to_group,
+    create_group,
+    delete_group,
+    get_groups,
+    remove_from_group,
+)
+from custom_components.matter_binding_helper.matter.models import GroupOperationResult
+
+
+@pytest.fixture
+def hass():
+    """Provide a mock Home Assistant instance."""
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_get_groups_returns_empty_list(hass):
+    """Listing groups returns an empty list (no managed groups yet)."""
+    result = await get_groups(hass)
+    assert result == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "operation",
+    [
+        lambda h: create_group(h, 1, "Living Room"),
+        lambda h: delete_group(h, 1),
+        lambda h: add_to_group(h, 1, 5, 1),
+        lambda h: remove_from_group(h, 1, 5, 1),
+    ],
+)
+async def test_mutations_report_not_supported(hass, operation):
+    """Every mutating group op returns an explicit not-supported result."""
+    result = await operation(hass)
+
+    assert isinstance(result, GroupOperationResult)
+    assert result.success is False
+    assert result.error_code == GROUP_NOT_SUPPORTED_CODE
+    assert result.message  # non-empty, user-facing
+
+
+@pytest.mark.asyncio
+async def test_result_to_dict_is_serializable(hass):
+    """The result serializes for the WebSocket layer."""
+    result = await create_group(hass, 42, "Bedroom")
+    payload = result.to_dict()
+
+    assert payload == {
+        "success": False,
+        "message": result.message,
+        "error_code": GROUP_NOT_SUPPORTED_CODE,
+    }


### PR DESCRIPTION
## Context
Matter group management is currently a **façade**: `matter/groups.py` stubs returned `False`/`[]` and the WS handlers reported a generic `*_failed` error, so the UI appeared to act while doing nothing. This is the first of a stacked series implementing full Matter groupcast.

## Changes
- **`GroupOperationResult`** (mirrors `ACLProvisioningResult`): group ops now return structured success/failure with a stable `error_code`.
- **groups.py**: mutations return an explicit `not_supported` result; `get_groups` returns `[]` (honest — no managed groups yet).
- **api.py**: group handlers surface `result.error_code`/`message` instead of generic `*_failed`.
- **const.py**: add `CLUSTER_GROUPS` (0x0004), `CLUSTER_GROUP_KEY_MANAGEMENT` (0x003F), `GROUP_KEY_SET_BASE`, `GROUP_KEY_SECURITY_POLICY_TRUST_FIRST`, `EVENT_GROUP_PROGRESS`, `GROUP_VERIFY_TIMEOUT/INTERVAL`.

## Tests
`tests/unit/test_groups.py` — gate returns not_supported; result serializes. `ruff check`/`format` clean.

> Stacked on #256.