### PR TITLE
feat(groups): persistent group + group-key registry (2/N)

### DIFF
--- a/custom_components/matter_binding_helper/api.py
+++ b/custom_components/matter_binding_helper/api.py
@@ -1259,11 +1259,13 @@ async def ws_create_group(
     msg: dict[str, Any],
 ) -> None:
     """Create a new Matter group."""
-    success = await matter_client.create_group(hass, msg["group_id"], msg["name"])
-    if success:
+    result = await matter_client.create_group(hass, msg["group_id"], msg["name"])
+    if result.success:
         connection.send_result(msg["id"], {"success": True})
     else:
-        connection.send_error(msg["id"], "create_failed", "Failed to create group")
+        connection.send_error(
+            msg["id"], result.error_code or "create_failed", result.message
+        )
 
 
 @websocket_api.websocket_command(
@@ -1279,11 +1281,13 @@ async def ws_delete_group(
     msg: dict[str, Any],
 ) -> None:
     """Delete a Matter group."""
-    success = await matter_client.delete_group(hass, msg["group_id"])
-    if success:
+    result = await matter_client.delete_group(hass, msg["group_id"])
+    if result.success:
         connection.send_result(msg["id"], {"success": True})
     else:
-        connection.send_error(msg["id"], "delete_failed", "Failed to delete group")
+        connection.send_error(
+            msg["id"], result.error_code or "delete_failed", result.message
+        )
 
 
 @websocket_api.websocket_command(
@@ -1301,13 +1305,15 @@ async def ws_add_to_group(
     msg: dict[str, Any],
 ) -> None:
     """Add an endpoint to a group."""
-    success = await matter_client.add_to_group(
+    result = await matter_client.add_to_group(
         hass, msg["group_id"], msg["node_id"], msg["endpoint_id"]
     )
-    if success:
+    if result.success:
         connection.send_result(msg["id"], {"success": True})
     else:
-        connection.send_error(msg["id"], "add_failed", "Failed to add to group")
+        connection.send_error(
+            msg["id"], result.error_code or "add_failed", result.message
+        )
 
 
 @websocket_api.websocket_command(
@@ -1325,13 +1331,15 @@ async def ws_remove_from_group(
     msg: dict[str, Any],
 ) -> None:
     """Remove an endpoint from a group."""
-    success = await matter_client.remove_from_group(
+    result = await matter_client.remove_from_group(
         hass, msg["group_id"], msg["node_id"], msg["endpoint_id"]
     )
-    if success:
+    if result.success:
         connection.send_result(msg["id"], {"success": True})
     else:
-        connection.send_error(msg["id"], "remove_failed", "Failed to remove from group")
+        connection.send_error(
+            msg["id"], result.error_code or "remove_failed", result.message
+        )
 
 
 # =============================================================================

--- a/custom_components/matter_binding_helper/const.py
+++ b/custom_components/matter_binding_helper/const.py
@@ -40,6 +40,8 @@ CLUSTER_SCENES = 0x0005
 CLUSTER_DESCRIPTOR = 0x001D  # Descriptor cluster
 CLUSTER_THERMOSTAT = 0x0201  # Thermostat cluster
 CLUSTER_ACCESS_CONTROL = 0x001F  # Access Control cluster
+CLUSTER_GROUPS = 0x0004  # Groups cluster (per-endpoint group membership)
+CLUSTER_GROUP_KEY_MANAGEMENT = 0x003F  # Group Key Management cluster (root endpoint)
 
 # WebSocket commands for thermostat schedules
 WS_TYPE_GET_SCHEDULE = f"{DOMAIN}/get_schedule"
@@ -87,6 +89,17 @@ ACL_AUTH_MODE_GROUP = 3  # Group messaging
 EVENT_ACL_PROGRESS = f"{DOMAIN}_acl_progress"
 ACL_VERIFY_TIMEOUT = 30  # seconds
 ACL_VERIFY_INTERVAL = 2  # seconds
+
+# Group Key Management
+# Group key set 0 is the reserved Identity Protection Key (IPK); application
+# group key sets are allocated from this base upward.
+GROUP_KEY_SET_BASE = 0x0100
+GROUP_KEY_SECURITY_POLICY_TRUST_FIRST = 0  # GroupKeySecurityPolicyEnum.kTrustFirst
+
+# Group provisioning progress events (mirrors ACL provisioning)
+EVENT_GROUP_PROGRESS = f"{DOMAIN}_group_progress"
+GROUP_VERIFY_TIMEOUT = 30  # seconds
+GROUP_VERIFY_INTERVAL = 2  # seconds
 
 # Cluster-to-privilege mapping for bindings
 # Maps cluster IDs to the minimum privilege required to operate on them

--- a/custom_components/matter_binding_helper/matter/group_store.py
+++ b/custom_components/matter_binding_helper/matter/group_store.py
@@ -1,0 +1,206 @@
+"""Persistent registry for Matter groups and their group keys.
+
+Matter groupcast requires a shared symmetric *group key* (an epoch key) to be
+written to every node in the group. Crucially, ``GroupKeyManagement.KeySetRead``
+returns the key set with the epoch key material **nulled** for security, so a key
+can never be read back off a device. To add a member to an existing group later,
+the integration must re-send the *same* epoch key — therefore it must persist the
+key it generated.
+
+This module is the single source of truth for that state: per group it records
+the name, the allocated group key set id, the epoch key (hex), and the member
+endpoints. It is pure registry/persistence logic with no Matter I/O — the actual
+device writes live in group_keys.py / groups.py.
+
+Security note: the epoch key is a fabric secret stored in HA's ``.storage`` (the
+same trust level as other HA secrets). Losing the store forces re-keying every
+group.
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from homeassistant.core import HomeAssistant
+
+from ..const import DOMAIN, GROUP_KEY_SET_BASE
+
+STORAGE_KEY = f"{DOMAIN}_groups"
+STORAGE_VERSION = 1
+EPOCH_KEY_BYTES = 16  # Matter group epoch keys are 128-bit
+
+
+def _default_epoch_key() -> str:
+    """Generate a fresh 128-bit epoch key as a hex string."""
+    return secrets.token_bytes(EPOCH_KEY_BYTES).hex()
+
+
+@dataclass
+class GroupRecord:
+    """A persisted Matter group and its key material."""
+
+    group_id: int
+    name: str
+    key_set_id: int
+    epoch_key: str  # hex of EPOCH_KEY_BYTES random bytes
+    members: list[dict[str, int]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for storage."""
+        return {
+            "group_id": self.group_id,
+            "name": self.name,
+            "key_set_id": self.key_set_id,
+            "epoch_key": self.epoch_key,
+            "members": self.members,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GroupRecord":
+        """Deserialize from storage."""
+        return cls(
+            group_id=int(data["group_id"]),
+            name=data["name"],
+            key_set_id=int(data["key_set_id"]),
+            epoch_key=data["epoch_key"],
+            members=[
+                {"node_id": int(m["node_id"]), "endpoint_id": int(m["endpoint_id"])}
+                for m in data.get("members", [])
+            ],
+        )
+
+    def has_member(self, node_id: int, endpoint_id: int) -> bool:
+        """Return True if (node_id, endpoint_id) is already a member."""
+        return any(
+            m["node_id"] == node_id and m["endpoint_id"] == endpoint_id
+            for m in self.members
+        )
+
+
+class GroupStore:
+    """Async, persistent CRUD over the group registry.
+
+    ``store`` is injectable for testing; by default it wraps HA's ``Store``.
+    ``key_factory`` lets tests pin deterministic epoch keys.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        store: Any | None = None,
+        key_factory: Callable[[], str] | None = None,
+    ) -> None:
+        if store is None:
+            # Imported lazily so the module loads under the unit-test HA mocks,
+            # which don't register homeassistant.helpers.storage.
+            from homeassistant.helpers.storage import Store
+
+            store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._store = store
+        self._key_factory = key_factory or _default_epoch_key
+        self._data: dict[str, Any] | None = None
+
+    # -- loading / saving -------------------------------------------------
+
+    async def async_load(self) -> None:
+        """Load the registry into memory (idempotent)."""
+        if self._data is not None:
+            return
+        raw = await self._store.async_load()
+        if not raw:
+            self._data = {"next_key_set_id": GROUP_KEY_SET_BASE, "groups": {}}
+        else:
+            self._data = {
+                "next_key_set_id": int(raw.get("next_key_set_id", GROUP_KEY_SET_BASE)),
+                "groups": dict(raw.get("groups", {})),
+            }
+
+    async def _save(self) -> None:
+        await self._store.async_save(self._data)
+
+    def _require_loaded(self) -> dict[str, Any]:
+        if self._data is None:
+            raise RuntimeError("GroupStore.async_load() must be called first")
+        return self._data
+
+    # -- queries ----------------------------------------------------------
+
+    def get_group(self, group_id: int) -> GroupRecord | None:
+        """Return the record for ``group_id`` or None."""
+        data = self._require_loaded()
+        raw = data["groups"].get(str(group_id))
+        return GroupRecord.from_dict(raw) if raw else None
+
+    def list_groups(self) -> list[GroupRecord]:
+        """Return all group records, ordered by group id."""
+        data = self._require_loaded()
+        records = [GroupRecord.from_dict(r) for r in data["groups"].values()]
+        return sorted(records, key=lambda r: r.group_id)
+
+    # -- mutations --------------------------------------------------------
+
+    async def async_create_group(self, group_id: int, name: str) -> GroupRecord:
+        """Create a group, allocating a key set id and a fresh epoch key.
+
+        Raises ValueError if the group already exists.
+        """
+        data = self._require_loaded()
+        key = str(group_id)
+        if key in data["groups"]:
+            raise ValueError(f"Group {group_id} already exists")
+
+        key_set_id = int(data["next_key_set_id"])
+        data["next_key_set_id"] = key_set_id + 1
+        record = GroupRecord(
+            group_id=group_id,
+            name=name,
+            key_set_id=key_set_id,
+            epoch_key=self._key_factory(),
+            members=[],
+        )
+        data["groups"][key] = record.to_dict()
+        await self._save()
+        return record
+
+    async def async_delete_group(self, group_id: int) -> bool:
+        """Delete a group. Returns True if it existed."""
+        data = self._require_loaded()
+        existed = data["groups"].pop(str(group_id), None) is not None
+        if existed:
+            await self._save()
+        return existed
+
+    async def async_add_member(
+        self, group_id: int, node_id: int, endpoint_id: int
+    ) -> GroupRecord:
+        """Add an endpoint to a group (idempotent). Raises if group missing."""
+        data = self._require_loaded()
+        record = self.get_group(group_id)
+        if record is None:
+            raise ValueError(f"Group {group_id} does not exist")
+        if not record.has_member(node_id, endpoint_id):
+            record.members.append({"node_id": node_id, "endpoint_id": endpoint_id})
+            data["groups"][str(group_id)] = record.to_dict()
+            await self._save()
+        return record
+
+    async def async_remove_member(
+        self, group_id: int, node_id: int, endpoint_id: int
+    ) -> GroupRecord:
+        """Remove an endpoint from a group (idempotent). Raises if group missing."""
+        data = self._require_loaded()
+        record = self.get_group(group_id)
+        if record is None:
+            raise ValueError(f"Group {group_id} does not exist")
+        before = len(record.members)
+        record.members = [
+            m
+            for m in record.members
+            if not (m["node_id"] == node_id and m["endpoint_id"] == endpoint_id)
+        ]
+        if len(record.members) != before:
+            data["groups"][str(group_id)] = record.to_dict()
+            await self._save()
+        return record

--- a/custom_components/matter_binding_helper/matter/groups.py
+++ b/custom_components/matter_binding_helper/matter/groups.py
@@ -1,7 +1,9 @@
 """Group operations for Matter devices.
 
-Note: These are placeholder stubs. Actual implementation depends on
-how python-matter-server exposes group management at the fabric level.
+Groupcast is implemented incrementally (see the group provisioning plan). Until
+the real Groups cluster + Group Key Management path lands, the mutating
+operations return an explicit "not supported" result instead of silently failing,
+so the UI can tell the user the truth rather than appearing to succeed/no-op.
 """
 
 from __future__ import annotations
@@ -10,49 +12,73 @@ import logging
 
 from homeassistant.core import HomeAssistant
 
-from .models import GroupEntry
+from .models import GroupEntry, GroupOperationResult
 
 _LOGGER = logging.getLogger(__name__)
+
+# Stable error code surfaced to the frontend while groupcast is unimplemented.
+GROUP_NOT_SUPPORTED_CODE = "not_supported"
+GROUP_NOT_SUPPORTED_MESSAGE = (
+    "Matter group management is not implemented yet. Group creation, membership "
+    "and groupcast bindings are coming in a future release."
+)
+
+
+def _not_supported() -> GroupOperationResult:
+    """Return the standard 'not yet supported' result for group mutations."""
+    return GroupOperationResult(
+        success=False,
+        message=GROUP_NOT_SUPPORTED_MESSAGE,
+        error_code=GROUP_NOT_SUPPORTED_CODE,
+    )
 
 
 async def get_groups(hass: HomeAssistant) -> list[GroupEntry]:
     """Get all Matter groups.
 
-    Groups in Matter are managed at the fabric level.
-    This is a placeholder - actual implementation depends on
-    how python-matter-server exposes group management.
+    Returns an empty list until group support is implemented. Listing nothing is
+    honest (there are no managed groups yet); only the mutating operations report
+    the unsupported state.
     """
-    _LOGGER.debug("Getting Matter groups")
+    _LOGGER.debug("get_groups: group support not implemented yet, returning []")
     return []
 
 
-async def create_group(hass: HomeAssistant, group_id: int, name: str) -> bool:
+async def create_group(
+    hass: HomeAssistant, group_id: int, name: str
+) -> GroupOperationResult:
     """Create a new Matter group."""
-    _LOGGER.debug("Creating group %s: %s", group_id, name)
-    return False
+    _LOGGER.debug("create_group: not supported yet (group %s: %s)", group_id, name)
+    return _not_supported()
 
 
-async def delete_group(hass: HomeAssistant, group_id: int) -> bool:
+async def delete_group(hass: HomeAssistant, group_id: int) -> GroupOperationResult:
     """Delete a Matter group."""
-    _LOGGER.debug("Deleting group %s", group_id)
-    return False
+    _LOGGER.debug("delete_group: not supported yet (group %s)", group_id)
+    return _not_supported()
 
 
 async def add_to_group(
     hass: HomeAssistant, group_id: int, node_id: int, endpoint_id: int
-) -> bool:
+) -> GroupOperationResult:
     """Add an endpoint to a group."""
     _LOGGER.debug(
-        "Adding node %s endpoint %s to group %s", node_id, endpoint_id, group_id
+        "add_to_group: not supported yet (node %s endpoint %s -> group %s)",
+        node_id,
+        endpoint_id,
+        group_id,
     )
-    return False
+    return _not_supported()
 
 
 async def remove_from_group(
     hass: HomeAssistant, group_id: int, node_id: int, endpoint_id: int
-) -> bool:
+) -> GroupOperationResult:
     """Remove an endpoint from a group."""
     _LOGGER.debug(
-        "Removing node %s endpoint %s from group %s", node_id, endpoint_id, group_id
+        "remove_from_group: not supported yet (node %s endpoint %s -> group %s)",
+        node_id,
+        endpoint_id,
+        group_id,
     )
-    return False
+    return _not_supported()

--- a/custom_components/matter_binding_helper/matter/models.py
+++ b/custom_components/matter_binding_helper/matter/models.py
@@ -142,6 +142,28 @@ class GroupEntry:
 
 
 @dataclass
+class GroupOperationResult:
+    """Result of a group management operation (create/delete/add/remove member).
+
+    Mirrors ACLProvisioningResult so the WebSocket layer can surface structured
+    success/failure. ``error_code`` is a stable, machine-readable string sent to
+    the frontend (e.g. ``"not_supported"`` while groupcast is unimplemented).
+    """
+
+    success: bool
+    message: str
+    error_code: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "success": self.success,
+            "message": self.message,
+            "error_code": self.error_code,
+        }
+
+
+@dataclass
 class ACLTarget:
     """Represents an ACL target restriction."""
 

--- a/custom_components/matter_binding_helper/matter_client.py
+++ b/custom_components/matter_binding_helper/matter_client.py
@@ -12,7 +12,7 @@ Module structure:
 - matter/bindings.py: Binding CRUD operations
 - matter/acl.py: Access Control List operations
 - matter/thermostat.py: Thermostat schedule operations
-- matter/groups.py: Group operations (stubs)
+- matter/groups.py: Group operations (not yet supported; honesty gate)
 - matter/proprietary.py: Proprietary attribute operations
 - matter/ha_registry.py: Home Assistant registry integration
 - matter/utils.py: Error handling and utilities
@@ -106,7 +106,7 @@ from .matter.thermostat import (
     supports_thermostat_schedule,
 )
 
-# Groups - group operations (stubs)
+# Groups - group operations (not yet supported; honesty gate)
 from .matter.groups import (
     add_to_group,
     create_group,

--- a/tests/unit/test_group_store.py
+++ b/tests/unit/test_group_store.py
@@ -1,0 +1,182 @@
+"""Unit tests for matter/group_store.py.
+
+Uses an in-memory fake Store and a deterministic key factory so the registry
+logic (CRUD, key-set-id allocation, epoch-key persistence) is testable without
+Home Assistant or hardware.
+"""
+
+import itertools
+
+import pytest
+from unittest.mock import MagicMock
+
+from custom_components.matter_binding_helper.const import GROUP_KEY_SET_BASE
+from custom_components.matter_binding_helper.matter.group_store import (
+    GroupRecord,
+    GroupStore,
+)
+
+
+class FakeStore:
+    """In-memory stand-in for homeassistant.helpers.storage.Store."""
+
+    def __init__(self, initial=None):
+        self.saved = initial
+        self.save_count = 0
+
+    async def async_load(self):
+        return self.saved
+
+    async def async_save(self, data):
+        # Emulate JSON round-trip so tests catch non-serializable state.
+        import json
+
+        self.saved = json.loads(json.dumps(data))
+        self.save_count += 1
+
+
+def _counter_keys():
+    """Deterministic epoch-key factory: 'key0001', 'key0002', ..."""
+    counter = itertools.count(1)
+    return lambda: f"key{next(counter):04d}"
+
+
+def make_store(initial=None):
+    return GroupStore(
+        MagicMock(), store=FakeStore(initial), key_factory=_counter_keys()
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_empty_initializes_defaults():
+    store = make_store()
+    await store.async_load()
+    assert store.list_groups() == []
+
+
+@pytest.mark.asyncio
+async def test_create_group_allocates_key_set_and_epoch_key():
+    store = make_store()
+    await store.async_load()
+
+    rec = await store.async_create_group(10, "Living Room")
+
+    assert isinstance(rec, GroupRecord)
+    assert rec.group_id == 10
+    assert rec.name == "Living Room"
+    assert rec.key_set_id == GROUP_KEY_SET_BASE
+    assert rec.epoch_key == "key0001"
+    assert rec.members == []
+
+
+@pytest.mark.asyncio
+async def test_key_set_ids_are_sequential_and_unique():
+    store = make_store()
+    await store.async_load()
+
+    a = await store.async_create_group(1, "A")
+    b = await store.async_create_group(2, "B")
+
+    assert a.key_set_id == GROUP_KEY_SET_BASE
+    assert b.key_set_id == GROUP_KEY_SET_BASE + 1
+    assert a.epoch_key != b.epoch_key
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_group_raises():
+    store = make_store()
+    await store.async_load()
+    await store.async_create_group(1, "A")
+
+    with pytest.raises(ValueError):
+        await store.async_create_group(1, "A again")
+
+
+@pytest.mark.asyncio
+async def test_add_member_is_idempotent():
+    store = make_store()
+    await store.async_load()
+    await store.async_create_group(1, "A")
+
+    await store.async_add_member(1, node_id=5, endpoint_id=1)
+    rec = await store.async_add_member(1, node_id=5, endpoint_id=1)
+
+    assert rec.members == [{"node_id": 5, "endpoint_id": 1}]
+
+
+@pytest.mark.asyncio
+async def test_remove_member():
+    store = make_store()
+    await store.async_load()
+    await store.async_create_group(1, "A")
+    await store.async_add_member(1, 5, 1)
+    await store.async_add_member(1, 6, 1)
+
+    rec = await store.async_remove_member(1, 5, 1)
+
+    assert rec.members == [{"node_id": 6, "endpoint_id": 1}]
+
+
+@pytest.mark.asyncio
+async def test_member_ops_on_missing_group_raise():
+    store = make_store()
+    await store.async_load()
+
+    with pytest.raises(ValueError):
+        await store.async_add_member(99, 5, 1)
+    with pytest.raises(ValueError):
+        await store.async_remove_member(99, 5, 1)
+
+
+@pytest.mark.asyncio
+async def test_delete_group():
+    store = make_store()
+    await store.async_load()
+    await store.async_create_group(1, "A")
+
+    assert await store.async_delete_group(1) is True
+    assert await store.async_delete_group(1) is False
+    assert store.get_group(1) is None
+
+
+@pytest.mark.asyncio
+async def test_persistence_round_trip_preserves_epoch_key():
+    """A second GroupStore over the same backing data sees the same key.
+
+    This is the critical property: the epoch key can't be read off devices, so
+    the store must reproduce it exactly for later member additions.
+    """
+    backing = FakeStore()
+    store1 = GroupStore(MagicMock(), store=backing, key_factory=_counter_keys())
+    await store1.async_load()
+    created = await store1.async_create_group(7, "Kitchen")
+    await store1.async_add_member(7, 5, 1)
+
+    # New store instance, same persisted bytes, fresh (unused) key factory.
+    store2 = GroupStore(
+        MagicMock(), store=FakeStore(backing.saved), key_factory=_counter_keys()
+    )
+    await store2.async_load()
+    reloaded = store2.get_group(7)
+
+    assert reloaded is not None
+    assert reloaded.epoch_key == created.epoch_key
+    assert reloaded.key_set_id == created.key_set_id
+    assert reloaded.members == [{"node_id": 5, "endpoint_id": 1}]
+
+
+@pytest.mark.asyncio
+async def test_next_key_set_id_survives_reload():
+    """Key-set-id allocation must not collide after a reload."""
+    backing = FakeStore()
+    store1 = GroupStore(MagicMock(), store=backing, key_factory=_counter_keys())
+    await store1.async_load()
+    await store1.async_create_group(1, "A")  # uses BASE
+
+    store2 = GroupStore(
+        MagicMock(), store=FakeStore(backing.saved), key_factory=_counter_keys()
+    )
+    await store2.async_load()
+    rec = await store2.async_create_group(2, "B")
+
+    assert rec.key_set_id == GROUP_KEY_SET_BASE + 1

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -1,0 +1,65 @@
+"""Unit tests for matter/groups.py.
+
+Covers the "honesty gate": until groupcast is implemented, mutating group
+operations must report an explicit unsupported result rather than silently
+no-op'ing, while listing returns an empty list.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from custom_components.matter_binding_helper.matter.groups import (
+    GROUP_NOT_SUPPORTED_CODE,
+    add_to_group,
+    create_group,
+    delete_group,
+    get_groups,
+    remove_from_group,
+)
+from custom_components.matter_binding_helper.matter.models import GroupOperationResult
+
+
+@pytest.fixture
+def hass():
+    """Provide a mock Home Assistant instance."""
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_get_groups_returns_empty_list(hass):
+    """Listing groups returns an empty list (no managed groups yet)."""
+    result = await get_groups(hass)
+    assert result == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "operation",
+    [
+        lambda h: create_group(h, 1, "Living Room"),
+        lambda h: delete_group(h, 1),
+        lambda h: add_to_group(h, 1, 5, 1),
+        lambda h: remove_from_group(h, 1, 5, 1),
+    ],
+)
+async def test_mutations_report_not_supported(hass, operation):
+    """Every mutating group op returns an explicit not-supported result."""
+    result = await operation(hass)
+
+    assert isinstance(result, GroupOperationResult)
+    assert result.success is False
+    assert result.error_code == GROUP_NOT_SUPPORTED_CODE
+    assert result.message  # non-empty, user-facing
+
+
+@pytest.mark.asyncio
+async def test_result_to_dict_is_serializable(hass):
+    """The result serializes for the WebSocket layer."""
+    result = await create_group(hass, 42, "Bedroom")
+    payload = result.to_dict()
+
+    assert payload == {
+        "success": False,
+        "message": result.message,
+        "error_code": GROUP_NOT_SUPPORTED_CODE,
+    }


### PR DESCRIPTION
## Context
Matter groupcast needs a shared epoch key written to every node in a group, and `GroupKeyManagement.KeySetRead` returns the key material **nulled** — so a key can never be read back off a device. To add members later we must re-send the *same* key, which means persisting it. This PR adds that store.

## Changes
- **`GroupRecord`**: group_id, name, allocated `key_set_id`, `epoch_key` (hex), members.
- **`GroupStore`**: async CRUD over HA `Store`; sequential key-set-id allocation from `GROUP_KEY_SET_BASE`; generates a 128-bit epoch key per group via `secrets`.
- Store + key factory are **injectable** for deterministic unit tests.
- Pure registry/persistence logic; no Matter I/O (device writes land in a later PR).

## Tests
`tests/unit/test_group_store.py` — CRUD, sequential id allocation, idempotent membership, and the critical **persistence round-trip** (epoch key reproduced exactly after reload). 10 tests.

> Stacked on #257.