### PR TITLE
feat(groups): group management in demo mode (3/N)

### DIFF
--- a/custom_components/matter_binding_helper/matter/demo.py
+++ b/custom_components/matter_binding_helper/matter/demo.py
@@ -20,7 +20,7 @@ from ..const import (
     DEFAULT_DEMO_MODE,
     DOMAIN,
 )
-from .models import ACLEntry, BindingEntry
+from .models import ACLEntry, BindingEntry, GroupEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -326,9 +326,69 @@ def remove_demo_acl_entry(node_id: int, source_node_id: int | None = None) -> bo
     return len(_demo_acl_entries[node_id]) < original_count
 
 
+def _default_demo_groups() -> dict[int, GroupEntry]:
+    """Build the initial demo group set."""
+    return {
+        1: GroupEntry(
+            group_id=1,
+            name="Living Room Lights",
+            members=[{"node_id": 1, "endpoint_id": 1}],
+        ),
+    }
+
+
+# Group storage for demo mode (keyed by group_id)
+_demo_groups: dict[int, GroupEntry] = _default_demo_groups()
+
+
+def get_demo_groups() -> list[GroupEntry]:
+    """Get all demo groups, ordered by group id."""
+    return [_demo_groups[gid] for gid in sorted(_demo_groups)]
+
+
+def create_demo_group(group_id: int, name: str) -> bool:
+    """Create a demo group. Returns False if it already exists."""
+    if group_id in _demo_groups:
+        return False
+    _demo_groups[group_id] = GroupEntry(group_id=group_id, name=name, members=[])
+    return True
+
+
+def delete_demo_group(group_id: int) -> bool:
+    """Delete a demo group. Returns True if it existed."""
+    return _demo_groups.pop(group_id, None) is not None
+
+
+def add_demo_group_member(group_id: int, node_id: int, endpoint_id: int) -> bool:
+    """Add an endpoint to a demo group (idempotent).
+
+    Returns False if the group does not exist.
+    """
+    group = _demo_groups.get(group_id)
+    if group is None:
+        return False
+    member = {"node_id": node_id, "endpoint_id": endpoint_id}
+    if member not in group.members:
+        group.members.append(member)
+    return True
+
+
+def remove_demo_group_member(group_id: int, node_id: int, endpoint_id: int) -> bool:
+    """Remove an endpoint from a demo group.
+
+    Returns False if the group does not exist.
+    """
+    group = _demo_groups.get(group_id)
+    if group is None:
+        return False
+    member = {"node_id": node_id, "endpoint_id": endpoint_id}
+    group.members = [m for m in group.members if m != member]
+    return True
+
+
 def reset_demo_data() -> None:
     """Reset all demo data to initial state."""
-    global _demo_bindings, _demo_acl_entries
+    global _demo_bindings, _demo_acl_entries, _demo_groups
 
     _demo_bindings = {
         (2, 1): [
@@ -352,3 +412,5 @@ def reset_demo_data() -> None:
     }
 
     _demo_acl_entries = {}
+
+    _demo_groups = _default_demo_groups()

--- a/custom_components/matter_binding_helper/matter/groups.py
+++ b/custom_components/matter_binding_helper/matter/groups.py
@@ -1,9 +1,11 @@
 """Group operations for Matter devices.
 
-Groupcast is implemented incrementally (see the group provisioning plan). Until
-the real Groups cluster + Group Key Management path lands, the mutating
-operations return an explicit "not supported" result instead of silently failing,
-so the UI can tell the user the truth rather than appearing to succeed/no-op.
+Groupcast is implemented incrementally (see the group provisioning plan). In demo
+mode, group management is fully functional against an in-memory store so the UI
+can be developed without hardware. On a real fabric, the mutating operations
+still return an explicit "not supported" result until the Groups cluster +
+Group Key Management path lands — so the UI tells the user the truth rather than
+appearing to succeed/no-op.
 """
 
 from __future__ import annotations
@@ -12,12 +14,22 @@ import logging
 
 from homeassistant.core import HomeAssistant
 
+from .demo import (
+    add_demo_group_member,
+    create_demo_group,
+    delete_demo_group,
+    get_demo_groups,
+    is_demo_mode,
+    remove_demo_group_member,
+)
 from .models import GroupEntry, GroupOperationResult
 
 _LOGGER = logging.getLogger(__name__)
 
-# Stable error code surfaced to the frontend while groupcast is unimplemented.
+# Stable error codes surfaced to the frontend.
 GROUP_NOT_SUPPORTED_CODE = "not_supported"
+GROUP_ALREADY_EXISTS_CODE = "already_exists"
+GROUP_NOT_FOUND_CODE = "not_found"
 GROUP_NOT_SUPPORTED_MESSAGE = (
     "Matter group management is not implemented yet. Group creation, membership "
     "and groupcast bindings are coming in a future release."
@@ -36,10 +48,12 @@ def _not_supported() -> GroupOperationResult:
 async def get_groups(hass: HomeAssistant) -> list[GroupEntry]:
     """Get all Matter groups.
 
-    Returns an empty list until group support is implemented. Listing nothing is
-    honest (there are no managed groups yet); only the mutating operations report
-    the unsupported state.
+    In demo mode, returns the in-memory demo groups. On a real fabric, returns an
+    empty list until group support is implemented (honest: no managed groups yet;
+    only the mutating operations report the unsupported state).
     """
+    if is_demo_mode(hass):
+        return get_demo_groups()
     _LOGGER.debug("get_groups: group support not implemented yet, returning []")
     return []
 
@@ -48,12 +62,28 @@ async def create_group(
     hass: HomeAssistant, group_id: int, name: str
 ) -> GroupOperationResult:
     """Create a new Matter group."""
+    if is_demo_mode(hass):
+        if not create_demo_group(group_id, name):
+            return GroupOperationResult(
+                success=False,
+                message=f"Group {group_id} already exists",
+                error_code=GROUP_ALREADY_EXISTS_CODE,
+            )
+        return GroupOperationResult(success=True, message=f"Created group {group_id}")
     _LOGGER.debug("create_group: not supported yet (group %s: %s)", group_id, name)
     return _not_supported()
 
 
 async def delete_group(hass: HomeAssistant, group_id: int) -> GroupOperationResult:
     """Delete a Matter group."""
+    if is_demo_mode(hass):
+        if not delete_demo_group(group_id):
+            return GroupOperationResult(
+                success=False,
+                message=f"Group {group_id} not found",
+                error_code=GROUP_NOT_FOUND_CODE,
+            )
+        return GroupOperationResult(success=True, message=f"Deleted group {group_id}")
     _LOGGER.debug("delete_group: not supported yet (group %s)", group_id)
     return _not_supported()
 
@@ -62,6 +92,17 @@ async def add_to_group(
     hass: HomeAssistant, group_id: int, node_id: int, endpoint_id: int
 ) -> GroupOperationResult:
     """Add an endpoint to a group."""
+    if is_demo_mode(hass):
+        if not add_demo_group_member(group_id, node_id, endpoint_id):
+            return GroupOperationResult(
+                success=False,
+                message=f"Group {group_id} not found",
+                error_code=GROUP_NOT_FOUND_CODE,
+            )
+        return GroupOperationResult(
+            success=True,
+            message=f"Added node {node_id} endpoint {endpoint_id} to group {group_id}",
+        )
     _LOGGER.debug(
         "add_to_group: not supported yet (node %s endpoint %s -> group %s)",
         node_id,
@@ -75,6 +116,19 @@ async def remove_from_group(
     hass: HomeAssistant, group_id: int, node_id: int, endpoint_id: int
 ) -> GroupOperationResult:
     """Remove an endpoint from a group."""
+    if is_demo_mode(hass):
+        if not remove_demo_group_member(group_id, node_id, endpoint_id):
+            return GroupOperationResult(
+                success=False,
+                message=f"Group {group_id} not found",
+                error_code=GROUP_NOT_FOUND_CODE,
+            )
+        return GroupOperationResult(
+            success=True,
+            message=(
+                f"Removed node {node_id} endpoint {endpoint_id} from group {group_id}"
+            ),
+        )
     _LOGGER.debug(
         "remove_from_group: not supported yet (node %s endpoint %s -> group %s)",
         node_id,

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -1,14 +1,20 @@
 """Unit tests for matter/groups.py.
 
-Covers the "honesty gate": until groupcast is implemented, mutating group
-operations must report an explicit unsupported result rather than silently
-no-op'ing, while listing returns an empty list.
+Covers two paths:
+- Honesty gate (real fabric): mutating ops report an explicit unsupported result
+  rather than silently no-op'ing; listing returns an empty list.
+- Demo mode: group management is fully functional against the in-memory demo
+  store so the UI can be developed without hardware.
 """
 
 import pytest
 from unittest.mock import MagicMock
 
+from custom_components.matter_binding_helper.const import CONF_DEMO_MODE
+from custom_components.matter_binding_helper.matter import demo
 from custom_components.matter_binding_helper.matter.groups import (
+    GROUP_ALREADY_EXISTS_CODE,
+    GROUP_NOT_FOUND_CODE,
     GROUP_NOT_SUPPORTED_CODE,
     add_to_group,
     create_group,
@@ -19,17 +25,49 @@ from custom_components.matter_binding_helper.matter.groups import (
 from custom_components.matter_binding_helper.matter.models import GroupOperationResult
 
 
+def _make_hass(demo_mode: bool) -> MagicMock:
+    """Build a mock hass whose config entry toggles demo mode."""
+    hass = MagicMock()
+    if demo_mode:
+        entry = MagicMock()
+        entry.options = {CONF_DEMO_MODE: True}
+        hass.config_entries.async_entries.return_value = [entry]
+    else:
+        hass.config_entries.async_entries.return_value = []
+    return hass
+
+
 @pytest.fixture
 def hass():
-    """Provide a mock Home Assistant instance."""
-    return MagicMock()
+    """Real-fabric (non-demo) hass."""
+    return _make_hass(demo_mode=False)
+
+
+def _reset_demo_groups() -> None:
+    """Reset only the demo group state, in place (no global rebind).
+
+    Mutating in place keeps object identity, so this never disturbs the other
+    demo stores (bindings/ACL) that sibling test modules hold references to.
+    """
+    demo._demo_groups.clear()
+    demo._demo_groups.update(demo._default_demo_groups())
+
+
+@pytest.fixture
+def demo_hass():
+    """Demo-mode hass with demo group data reset around the test."""
+    _reset_demo_groups()
+    yield _make_hass(demo_mode=True)
+    _reset_demo_groups()
+
+
+# --- Honesty gate (real fabric) -------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_get_groups_returns_empty_list(hass):
-    """Listing groups returns an empty list (no managed groups yet)."""
-    result = await get_groups(hass)
-    assert result == []
+    """Listing groups returns an empty list on a real fabric (none managed yet)."""
+    assert await get_groups(hass) == []
 
 
 @pytest.mark.asyncio
@@ -56,10 +94,66 @@ async def test_mutations_report_not_supported(hass, operation):
 async def test_result_to_dict_is_serializable(hass):
     """The result serializes for the WebSocket layer."""
     result = await create_group(hass, 42, "Bedroom")
-    payload = result.to_dict()
-
-    assert payload == {
+    assert result.to_dict() == {
         "success": False,
         "message": result.message,
         "error_code": GROUP_NOT_SUPPORTED_CODE,
     }
+
+
+# --- Demo mode -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_demo_lists_seed_group(demo_hass):
+    """Demo mode ships a seed group so the UI has content."""
+    groups = await get_groups(demo_hass)
+    assert [g.group_id for g in groups] == [1]
+    assert groups[0].name == "Living Room Lights"
+
+
+@pytest.mark.asyncio
+async def test_demo_create_and_list(demo_hass):
+    result = await create_group(demo_hass, 2, "Kitchen")
+    assert result.success is True
+
+    groups = await get_groups(demo_hass)
+    assert {g.group_id for g in groups} == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_demo_create_duplicate_reports_exists(demo_hass):
+    result = await create_group(demo_hass, 1, "Dup")
+    assert result.success is False
+    assert result.error_code == GROUP_ALREADY_EXISTS_CODE
+
+
+@pytest.mark.asyncio
+async def test_demo_add_and_remove_member(demo_hass):
+    add = await add_to_group(demo_hass, 1, node_id=7, endpoint_id=1)
+    assert add.success is True
+    members = (await get_groups(demo_hass))[0].members
+    assert {"node_id": 7, "endpoint_id": 1} in members
+
+    remove = await remove_from_group(demo_hass, 1, node_id=7, endpoint_id=1)
+    assert remove.success is True
+    members = (await get_groups(demo_hass))[0].members
+    assert {"node_id": 7, "endpoint_id": 1} not in members
+
+
+@pytest.mark.asyncio
+async def test_demo_member_ops_on_missing_group_report_not_found(demo_hass):
+    add = await add_to_group(demo_hass, 999, 5, 1)
+    assert add.success is False
+    assert add.error_code == GROUP_NOT_FOUND_CODE
+
+
+@pytest.mark.asyncio
+async def test_demo_delete_group(demo_hass):
+    result = await delete_group(demo_hass, 1)
+    assert result.success is True
+    assert await get_groups(demo_hass) == []
+
+    missing = await delete_group(demo_hass, 1)
+    assert missing.success is False
+    assert missing.error_code == GROUP_NOT_FOUND_CODE


### PR DESCRIPTION
## Context
Lets the group-management UI be developed and tested without hardware, while the real fabric still returns the honest `not_supported` gate until the Groups cluster path lands.

## Changes
- **demo.py**: in-memory `_demo_groups` store + create/delete/add/remove/list helpers, seeded with a 'Living Room Lights' group; reset wired into `reset_demo_data`.
- **groups.py**: branch on `is_demo_mode` — demo mode performs real CRUD returning structured `GroupOperationResult` (`already_exists`/`not_found` codes); real fabric unchanged.

## Tests
`test_groups.py` split into gate vs demo coverage: demo CRUD, idempotent membership, duplicate/missing-group error codes. The `demo_hass` fixture resets only group state **in place** to avoid disturbing sibling demo stores (caught an ordering-dependent isolation bug). Full unit suite green (185).

> Stacked on #258.