### PR TITLE
feat(devices): add Groups cluster to rs-matter mock devices (4/N)

### DIFF
--- a/devices/README.md
+++ b/devices/README.md
@@ -34,6 +34,7 @@ A Matter dimmable light (device type 0x0101) with:
 | On/Off | 0x0006 | On/off control |
 | Level Control | 0x0008 | Brightness dimming |
 | Binding | 0x001E | Device-to-device bindings |
+| Groups | 0x0004 | Group membership (groupcast target) |
 | Descriptor | 0x001D | Device description |
 
 **Configuration (via environment variables):**
@@ -54,6 +55,7 @@ A Matter on/off light switch (device type 0x0103) that controls other devices vi
 | Cluster | ID | Description |
 |---------|------|-------------|
 | Binding | 0x001E | Device-to-device bindings (targets for control) |
+| Groups | 0x0004 | Group membership (groupcast target) |
 | Descriptor | 0x001D | Device description |
 
 **Configuration (via environment variables):**

--- a/devices/rust-device/src/bin/dimmable_light.rs
+++ b/devices/rust-device/src/bin/dimmable_light.rs
@@ -28,6 +28,7 @@ use rs_matter::dm::clusters::decl::level_control::{
 };
 use rs_matter::dm::clusters::decl::on_off as on_off_cluster;
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
+use rs_matter::dm::clusters::groups::{ClusterHandler as _, GroupsHandler};
 use rs_matter::dm::clusters::net_comm::SharedNetworks;
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_DIMMABLE_LIGHT;
@@ -231,6 +232,7 @@ const NODE: Node<'static> = Node {
                 OnOffDeviceLogic::CLUSTER,
                 LevelControlDeviceLogic::CLUSTER,
                 BindingHandler::CLUSTER,
+                GroupsHandler::CLUSTER,
             ),
         ),
     ],
@@ -265,8 +267,34 @@ fn dm_handler<'a, LH: LevelControlHooks, OH: OnOffHooks>(
             .chain(
                 EpClMatcher::new(Some(1), Some(BindingHandler::CLUSTER.id)),
                 Async(binding.adapt()),
+            )
+            .chain(
+                EpClMatcher::new(Some(1), Some(GroupsHandler::CLUSTER.id)),
+                Async(GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             ),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Endpoint 1 must advertise the Groups cluster (0x0004) so the light can be
+    /// added to a Matter group and actuated via groupcast On/Off / Level Control.
+    #[test]
+    fn endpoint1_exposes_groups_cluster() {
+        let ep = NODE
+            .endpoints
+            .iter()
+            .find(|e| e.id == 1)
+            .expect("application endpoint 1");
+        assert!(
+            ep.clusters
+                .iter()
+                .any(|c| c.id == GroupsHandler::CLUSTER.id),
+            "Groups cluster (0x0004) not registered on endpoint 1"
+        );
+    }
 }
 
 // ============================================================================

--- a/devices/rust-device/src/bin/on_off_switch.rs
+++ b/devices/rust-device/src/bin/on_off_switch.rs
@@ -21,6 +21,7 @@ use rand::RngCore;
 
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
+use rs_matter::dm::clusters::groups::{ClusterHandler as _, GroupsHandler};
 use rs_matter::dm::clusters::net_comm::SharedNetworks;
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::endpoints::EthSysHandlerBuilder;
@@ -198,7 +199,11 @@ const NODE: Node<'static> = Node {
         Endpoint::new(
             1,
             devices!(DEV_TYPE_ON_OFF_LIGHT_SWITCH),
-            clusters!(desc::DescHandler::CLUSTER, BindingHandler::CLUSTER,),
+            clusters!(
+                desc::DescHandler::CLUSTER,
+                BindingHandler::CLUSTER,
+                GroupsHandler::CLUSTER,
+            ),
         ),
     ],
 };
@@ -222,6 +227,32 @@ fn dm_handler<'a>(
             .chain(
                 EpClMatcher::new(Some(1), Some(BindingHandler::CLUSTER.id)),
                 Async(binding.adapt()),
+            )
+            .chain(
+                EpClMatcher::new(Some(1), Some(GroupsHandler::CLUSTER.id)),
+                Async(GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             ),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Endpoint 1 must advertise the Groups cluster (0x0004) so the device can
+    /// be added to a Matter group and respond to groupcast.
+    #[test]
+    fn endpoint1_exposes_groups_cluster() {
+        let ep = NODE
+            .endpoints
+            .iter()
+            .find(|e| e.id == 1)
+            .expect("application endpoint 1");
+        assert!(
+            ep.clusters
+                .iter()
+                .any(|c| c.id == GroupsHandler::CLUSTER.id),
+            "Groups cluster (0x0004) not registered on endpoint 1"
+        );
+    }
 }


### PR DESCRIPTION
## Context
Enables end-to-end groupcast testing in CI, and **resolves the plan's highest risk**. Investigation of rs-matter (e8b0b0c) found it fully supports groups:
- `GroupsHandler` (0x0004) is addable to an application endpoint.
- `GrpKeyMgmtHandler` (0x003F) is **already on the root node automatically**.
- The transport layer **receives and decrypts groupcast** (`get_or_create_for_group_rx`, IPv6 multicast, on-the-fly group-key derivation).

So the mocks can actually **actuate** on groupcast — later integration tests can assert real behavior, not just provisioning.

## Changes
- `dimmable_light` + `on_off_switch`: register `GroupsHandler::CLUSTER` on endpoint 1 and chain the handler (mirrors existing `BindingHandler` wiring).
- devices/README.md: document the new cluster.

## Tests
Per-binary `#[cfg(test)]` test asserts the Groups cluster is registered on endpoint 1 (`cargo test --bins` — 2 pass). `cargo check`/`fmt` clean.

**Manual smoke (needs Docker):** `make devices-start` then `./matter.sh cluster <node> 1 4` and `... 0 63` show the Groups and Group Key Management clusters.

> Stacked on #259.