### PR TITLE
feat(groups): real Groups cluster membership (6/N)

### DIFF
--- a/custom_components/matter_binding_helper/matter/group_store.py
+++ b/custom_components/matter_binding_helper/matter/group_store.py
@@ -27,9 +27,27 @@ from homeassistant.core import HomeAssistant
 
 from ..const import DOMAIN, GROUP_KEY_SET_BASE
 
+
+def get_group_store(hass: HomeAssistant) -> "GroupStore":
+    """Return the cached GroupStore for this hass, creating it on first use.
+
+    Tests can pre-seed ``hass.data[DOMAIN][_GROUP_STORE_KEY]`` with a GroupStore
+    built around a fake backing store to avoid touching HA storage.
+    """
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    store = domain_data.get(_GROUP_STORE_KEY)
+    if store is None:
+        store = GroupStore(hass)
+        domain_data[_GROUP_STORE_KEY] = store
+    return store
+
+
 STORAGE_KEY = f"{DOMAIN}_groups"
 STORAGE_VERSION = 1
 EPOCH_KEY_BYTES = 16  # Matter group epoch keys are 128-bit
+
+# Key under hass.data[DOMAIN] for the cached GroupStore singleton.
+_GROUP_STORE_KEY = "_group_store"
 
 
 def _default_epoch_key() -> str:

--- a/custom_components/matter_binding_helper/matter/groups.py
+++ b/custom_components/matter_binding_helper/matter/groups.py
@@ -1,19 +1,24 @@
 """Group operations for Matter devices.
 
-Groupcast is implemented incrementally (see the group provisioning plan). In demo
-mode, group management is fully functional against an in-memory store so the UI
-can be developed without hardware. On a real fabric, the mutating operations
-still return an explicit "not supported" result until the Groups cluster +
-Group Key Management path lands — so the UI tells the user the truth rather than
-appearing to succeed/no-op.
+Two backends:
+- Demo mode: in-memory store so the UI works without hardware.
+- Real fabric: groups are tracked in the persistent GroupStore (names + group
+  keys), membership is provisioned on devices via Group Key Management
+  (``KeySetWrite`` + ``GroupKeyMap``) followed by the Groups cluster
+  (``AddGroup`` / ``RemoveGroup``). Matter has no "create group" command — a
+  group exists once a device holds its key material and is added to it — so
+  create/delete operate on the registry and add/remove touch the devices.
 """
 
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 
+from ..const import CLUSTER_GROUPS
+from .client import get_raw_matter_client
 from .demo import (
     add_demo_group_member,
     create_demo_group,
@@ -22,6 +27,8 @@ from .demo import (
     is_demo_mode,
     remove_demo_group_member,
 )
+from .group_keys import provision_group_key
+from .group_store import get_group_store
 from .models import GroupEntry, GroupOperationResult
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,38 +37,65 @@ _LOGGER = logging.getLogger(__name__)
 GROUP_NOT_SUPPORTED_CODE = "not_supported"
 GROUP_ALREADY_EXISTS_CODE = "already_exists"
 GROUP_NOT_FOUND_CODE = "not_found"
+GROUP_DEVICE_ERROR_CODE = "device_error"
 GROUP_NOT_SUPPORTED_MESSAGE = (
-    "Matter group management is not implemented yet. Group creation, membership "
-    "and groupcast bindings are coming in a future release."
+    "Matter group management is not available (Matter client not connected)."
 )
 
 
-def _not_supported() -> GroupOperationResult:
-    """Return the standard 'not yet supported' result for group mutations."""
+def _client_unavailable() -> GroupOperationResult:
     return GroupOperationResult(
         success=False,
         message=GROUP_NOT_SUPPORTED_MESSAGE,
-        error_code=GROUP_NOT_SUPPORTED_CODE,
+        error_code="client_unavailable",
     )
 
 
-async def get_groups(hass: HomeAssistant) -> list[GroupEntry]:
-    """Get all Matter groups.
+def _add_group_command(group_id: int, name: str) -> Any:
+    """Build the chip Groups.AddGroup command (chip imported lazily)."""
+    from chip.clusters import Objects as clusters
 
-    In demo mode, returns the in-memory demo groups. On a real fabric, returns an
-    empty list until group support is implemented (honest: no managed groups yet;
-    only the mutating operations report the unsupported state).
-    """
+    return clusters.Groups.Commands.AddGroup(groupID=group_id, groupName=name)
+
+
+def _remove_group_command(group_id: int) -> Any:
+    """Build the chip Groups.RemoveGroup command (chip imported lazily)."""
+    from chip.clusters import Objects as clusters
+
+    return clusters.Groups.Commands.RemoveGroup(groupID=group_id)
+
+
+def _response_status(response: Any) -> int | None:
+    """Extract the status field from a Groups command response (0 = success)."""
+    if response is None:
+        return None
+    if isinstance(response, dict):
+        val = response.get("status", response.get("0"))
+    else:
+        val = getattr(response, "status", None)
+    try:
+        return int(val) if val is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+async def get_groups(hass: HomeAssistant) -> list[GroupEntry]:
+    """Get all Matter groups (from the registry, or demo store in demo mode)."""
     if is_demo_mode(hass):
         return get_demo_groups()
-    _LOGGER.debug("get_groups: group support not implemented yet, returning []")
-    return []
+
+    store = get_group_store(hass)
+    await store.async_load()
+    return [
+        GroupEntry(group_id=r.group_id, name=r.name, members=list(r.members))
+        for r in store.list_groups()
+    ]
 
 
 async def create_group(
     hass: HomeAssistant, group_id: int, name: str
 ) -> GroupOperationResult:
-    """Create a new Matter group."""
+    """Create a new Matter group (allocates a group key set in the registry)."""
     if is_demo_mode(hass):
         if not create_demo_group(group_id, name):
             return GroupOperationResult(
@@ -70,12 +104,21 @@ async def create_group(
                 error_code=GROUP_ALREADY_EXISTS_CODE,
             )
         return GroupOperationResult(success=True, message=f"Created group {group_id}")
-    _LOGGER.debug("create_group: not supported yet (group %s: %s)", group_id, name)
-    return _not_supported()
+
+    store = get_group_store(hass)
+    await store.async_load()
+    if store.get_group(group_id) is not None:
+        return GroupOperationResult(
+            success=False,
+            message=f"Group {group_id} already exists",
+            error_code=GROUP_ALREADY_EXISTS_CODE,
+        )
+    await store.async_create_group(group_id, name)
+    return GroupOperationResult(success=True, message=f"Created group {group_id}")
 
 
 async def delete_group(hass: HomeAssistant, group_id: int) -> GroupOperationResult:
-    """Delete a Matter group."""
+    """Delete a Matter group, best-effort removing it from member devices."""
     if is_demo_mode(hass):
         if not delete_demo_group(group_id):
             return GroupOperationResult(
@@ -84,14 +127,46 @@ async def delete_group(hass: HomeAssistant, group_id: int) -> GroupOperationResu
                 error_code=GROUP_NOT_FOUND_CODE,
             )
         return GroupOperationResult(success=True, message=f"Deleted group {group_id}")
-    _LOGGER.debug("delete_group: not supported yet (group %s)", group_id)
-    return _not_supported()
+
+    store = get_group_store(hass)
+    await store.async_load()
+    record = store.get_group(group_id)
+    if record is None:
+        return GroupOperationResult(
+            success=False,
+            message=f"Group {group_id} not found",
+            error_code=GROUP_NOT_FOUND_CODE,
+        )
+
+    client = get_raw_matter_client(hass)
+    if client:
+        for member in record.members:
+            try:
+                await client.send_device_command(
+                    node_id=member["node_id"],
+                    endpoint_id=member["endpoint_id"],
+                    command=_remove_group_command(group_id),
+                )
+            except Exception as err:  # noqa: BLE001 - best-effort cleanup
+                _LOGGER.warning(
+                    "delete_group: RemoveGroup failed on node %s ep %s: %s",
+                    member["node_id"],
+                    member["endpoint_id"],
+                    err,
+                )
+
+    await store.async_delete_group(group_id)
+    return GroupOperationResult(success=True, message=f"Deleted group {group_id}")
 
 
 async def add_to_group(
     hass: HomeAssistant, group_id: int, node_id: int, endpoint_id: int
 ) -> GroupOperationResult:
-    """Add an endpoint to a group."""
+    """Add an endpoint to a group.
+
+    Provisions the group key on the node (prerequisite), then issues
+    ``Groups.AddGroup`` and records membership.
+    """
     if is_demo_mode(hass):
         if not add_demo_group_member(group_id, node_id, endpoint_id):
             return GroupOperationResult(
@@ -103,19 +178,63 @@ async def add_to_group(
             success=True,
             message=f"Added node {node_id} endpoint {endpoint_id} to group {group_id}",
         )
-    _LOGGER.debug(
-        "add_to_group: not supported yet (node %s endpoint %s -> group %s)",
-        node_id,
-        endpoint_id,
-        group_id,
+
+    store = get_group_store(hass)
+    await store.async_load()
+    record = store.get_group(group_id)
+    if record is None:
+        return GroupOperationResult(
+            success=False,
+            message=f"Group {group_id} not found",
+            error_code=GROUP_NOT_FOUND_CODE,
+        )
+
+    client = get_raw_matter_client(hass)
+    if not client:
+        return _client_unavailable()
+
+    # 1. Provision the group key on this node (AddGroup is rejected without it).
+    key_result = await provision_group_key(
+        hass, node_id, group_id, record.key_set_id, record.epoch_key
     )
-    return _not_supported()
+    if not key_result.success:
+        return key_result
+
+    # 2. Add the endpoint to the group via the Groups cluster.
+    try:
+        response = await client.send_device_command(
+            node_id=node_id,
+            endpoint_id=endpoint_id,
+            command=_add_group_command(group_id, record.name),
+        )
+    except Exception as err:  # noqa: BLE001 - surfaced to the user
+        _LOGGER.error("add_to_group: AddGroup failed: %s", err, exc_info=True)
+        return GroupOperationResult(
+            success=False,
+            message=f"AddGroup failed: {err}",
+            error_code=GROUP_DEVICE_ERROR_CODE,
+        )
+
+    status = _response_status(response)
+    if status not in (0, None):
+        return GroupOperationResult(
+            success=False,
+            message=f"Device rejected AddGroup (status {status})",
+            error_code=GROUP_DEVICE_ERROR_CODE,
+        )
+
+    # 3. Record membership.
+    await store.async_add_member(group_id, node_id, endpoint_id)
+    return GroupOperationResult(
+        success=True,
+        message=f"Added node {node_id} endpoint {endpoint_id} to group {group_id}",
+    )
 
 
 async def remove_from_group(
     hass: HomeAssistant, group_id: int, node_id: int, endpoint_id: int
 ) -> GroupOperationResult:
-    """Remove an endpoint from a group."""
+    """Remove an endpoint from a group via ``Groups.RemoveGroup``."""
     if is_demo_mode(hass):
         if not remove_demo_group_member(group_id, node_id, endpoint_id):
             return GroupOperationResult(
@@ -129,10 +248,55 @@ async def remove_from_group(
                 f"Removed node {node_id} endpoint {endpoint_id} from group {group_id}"
             ),
         )
-    _LOGGER.debug(
-        "remove_from_group: not supported yet (node %s endpoint %s -> group %s)",
-        node_id,
-        endpoint_id,
-        group_id,
+
+    store = get_group_store(hass)
+    await store.async_load()
+    if store.get_group(group_id) is None:
+        return GroupOperationResult(
+            success=False,
+            message=f"Group {group_id} not found",
+            error_code=GROUP_NOT_FOUND_CODE,
+        )
+
+    client = get_raw_matter_client(hass)
+    if not client:
+        return _client_unavailable()
+
+    try:
+        response = await client.send_device_command(
+            node_id=node_id,
+            endpoint_id=endpoint_id,
+            command=_remove_group_command(group_id),
+        )
+    except Exception as err:  # noqa: BLE001 - surfaced to the user
+        _LOGGER.error("remove_from_group: RemoveGroup failed: %s", err, exc_info=True)
+        return GroupOperationResult(
+            success=False,
+            message=f"RemoveGroup failed: {err}",
+            error_code=GROUP_DEVICE_ERROR_CODE,
+        )
+
+    status = _response_status(response)
+    if status not in (0, None):
+        return GroupOperationResult(
+            success=False,
+            message=f"Device rejected RemoveGroup (status {status})",
+            error_code=GROUP_DEVICE_ERROR_CODE,
+        )
+
+    await store.async_remove_member(group_id, node_id, endpoint_id)
+    return GroupOperationResult(
+        success=True,
+        message=f"Removed node {node_id} endpoint {endpoint_id} from group {group_id}",
     )
-    return _not_supported()
+
+
+# CLUSTER_GROUPS is re-exported for callers that need the Groups cluster id.
+__all__ = [
+    "CLUSTER_GROUPS",
+    "add_to_group",
+    "create_group",
+    "delete_group",
+    "get_groups",
+    "remove_from_group",
+]

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -1,124 +1,163 @@
 """Unit tests for matter/groups.py.
 
-Covers two paths:
-- Honesty gate (real fabric): mutating ops report an explicit unsupported result
-  rather than silently no-op'ing; listing returns an empty list.
-- Demo mode: group management is fully functional against the in-memory demo
-  store so the UI can be developed without hardware.
+Covers:
+- Demo mode: full in-memory CRUD.
+- Real fabric: registry-backed create/delete/list and the guard branches of
+  add/remove (group-missing, client-unavailable). The on-device AddGroup/
+  RemoveGroup path is chip-dependent and covered by the PR8 integration test.
 """
 
-import pytest
-from unittest.mock import MagicMock
+import itertools
+from unittest.mock import MagicMock, patch
 
-from custom_components.matter_binding_helper.const import CONF_DEMO_MODE
-from custom_components.matter_binding_helper.matter import demo
+import pytest
+
+from custom_components.matter_binding_helper.const import CONF_DEMO_MODE, DOMAIN
+from custom_components.matter_binding_helper.matter import demo, groups
 from custom_components.matter_binding_helper.matter.groups import (
     GROUP_ALREADY_EXISTS_CODE,
     GROUP_NOT_FOUND_CODE,
-    GROUP_NOT_SUPPORTED_CODE,
     add_to_group,
     create_group,
     delete_group,
     get_groups,
     remove_from_group,
 )
-from custom_components.matter_binding_helper.matter.models import GroupOperationResult
+from custom_components.matter_binding_helper.matter.group_store import (
+    _GROUP_STORE_KEY,
+    GroupStore,
+)
+
+
+class FakeStore:
+    """In-memory stand-in for homeassistant.helpers.storage.Store."""
+
+    def __init__(self):
+        self.saved = None
+
+    async def async_load(self):
+        return self.saved
+
+    async def async_save(self, data):
+        import json
+
+        self.saved = json.loads(json.dumps(data))
+
+
+def _keys():
+    counter = itertools.count(1)
+    return lambda: f"key{next(counter):04d}"
 
 
 def _make_hass(demo_mode: bool) -> MagicMock:
-    """Build a mock hass whose config entry toggles demo mode."""
     hass = MagicMock()
+    hass.data = {}
     if demo_mode:
         entry = MagicMock()
         entry.options = {CONF_DEMO_MODE: True}
         hass.config_entries.async_entries.return_value = [entry]
     else:
         hass.config_entries.async_entries.return_value = []
+        # Seed a GroupStore backed by an in-memory fake store.
+        store = GroupStore(MagicMock(), store=FakeStore(), key_factory=_keys())
+        hass.data[DOMAIN] = {_GROUP_STORE_KEY: store}
     return hass
+
+
+# --- Real fabric (registry-backed) ----------------------------------------
 
 
 @pytest.fixture
 def hass():
-    """Real-fabric (non-demo) hass."""
     return _make_hass(demo_mode=False)
 
 
-def _reset_demo_groups() -> None:
-    """Reset only the demo group state, in place (no global rebind).
+@pytest.mark.asyncio
+async def test_real_create_and_list(hass):
+    result = await create_group(hass, 10, "Hallway")
+    assert result.success is True
 
-    Mutating in place keeps object identity, so this never disturbs the other
-    demo stores (bindings/ACL) that sibling test modules hold references to.
-    """
+    listed = await get_groups(hass)
+    assert [g.group_id for g in listed] == [10]
+    assert listed[0].name == "Hallway"
+
+
+@pytest.mark.asyncio
+async def test_real_create_duplicate(hass):
+    await create_group(hass, 10, "Hallway")
+    dup = await create_group(hass, 10, "Hallway")
+    assert dup.success is False
+    assert dup.error_code == GROUP_ALREADY_EXISTS_CODE
+
+
+@pytest.mark.asyncio
+async def test_real_delete_missing_group(hass):
+    result = await delete_group(hass, 999)
+    assert result.success is False
+    assert result.error_code == GROUP_NOT_FOUND_CODE
+
+
+@pytest.mark.asyncio
+async def test_real_delete_empty_group(hass):
+    await create_group(hass, 10, "Hallway")
+    with patch.object(groups, "get_raw_matter_client", return_value=None):
+        result = await delete_group(hass, 10)
+    assert result.success is True
+    assert await get_groups(hass) == []
+
+
+@pytest.mark.asyncio
+async def test_real_add_to_missing_group(hass):
+    result = await add_to_group(hass, 999, 5, 1)
+    assert result.success is False
+    assert result.error_code == GROUP_NOT_FOUND_CODE
+
+
+@pytest.mark.asyncio
+async def test_real_add_client_unavailable(hass):
+    await create_group(hass, 10, "Hallway")
+    with patch.object(groups, "get_raw_matter_client", return_value=None):
+        result = await add_to_group(hass, 10, 5, 1)
+    assert result.success is False
+    assert result.error_code == "client_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_real_remove_client_unavailable(hass):
+    await create_group(hass, 10, "Hallway")
+    with patch.object(groups, "get_raw_matter_client", return_value=None):
+        result = await remove_from_group(hass, 10, 5, 1)
+    assert result.success is False
+    assert result.error_code == "client_unavailable"
+
+
+# --- Demo mode -------------------------------------------------------------
+
+
+def _reset_demo_groups() -> None:
     demo._demo_groups.clear()
     demo._demo_groups.update(demo._default_demo_groups())
 
 
 @pytest.fixture
 def demo_hass():
-    """Demo-mode hass with demo group data reset around the test."""
     _reset_demo_groups()
     yield _make_hass(demo_mode=True)
     _reset_demo_groups()
 
 
-# --- Honesty gate (real fabric) -------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_get_groups_returns_empty_list(hass):
-    """Listing groups returns an empty list on a real fabric (none managed yet)."""
-    assert await get_groups(hass) == []
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "operation",
-    [
-        lambda h: create_group(h, 1, "Living Room"),
-        lambda h: delete_group(h, 1),
-        lambda h: add_to_group(h, 1, 5, 1),
-        lambda h: remove_from_group(h, 1, 5, 1),
-    ],
-)
-async def test_mutations_report_not_supported(hass, operation):
-    """Every mutating group op returns an explicit not-supported result."""
-    result = await operation(hass)
-
-    assert isinstance(result, GroupOperationResult)
-    assert result.success is False
-    assert result.error_code == GROUP_NOT_SUPPORTED_CODE
-    assert result.message  # non-empty, user-facing
-
-
-@pytest.mark.asyncio
-async def test_result_to_dict_is_serializable(hass):
-    """The result serializes for the WebSocket layer."""
-    result = await create_group(hass, 42, "Bedroom")
-    assert result.to_dict() == {
-        "success": False,
-        "message": result.message,
-        "error_code": GROUP_NOT_SUPPORTED_CODE,
-    }
-
-
-# --- Demo mode -------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_demo_lists_seed_group(demo_hass):
-    """Demo mode ships a seed group so the UI has content."""
-    groups = await get_groups(demo_hass)
-    assert [g.group_id for g in groups] == [1]
-    assert groups[0].name == "Living Room Lights"
+    groups_list = await get_groups(demo_hass)
+    assert [g.group_id for g in groups_list] == [1]
+    assert groups_list[0].name == "Living Room Lights"
 
 
 @pytest.mark.asyncio
 async def test_demo_create_and_list(demo_hass):
     result = await create_group(demo_hass, 2, "Kitchen")
     assert result.success is True
-
-    groups = await get_groups(demo_hass)
-    assert {g.group_id for g in groups} == {1, 2}
+    assert {g.group_id for g in await get_groups(demo_hass)} == {1, 2}
 
 
 @pytest.mark.asyncio
@@ -132,8 +171,7 @@ async def test_demo_create_duplicate_reports_exists(demo_hass):
 async def test_demo_add_and_remove_member(demo_hass):
     add = await add_to_group(demo_hass, 1, node_id=7, endpoint_id=1)
     assert add.success is True
-    members = (await get_groups(demo_hass))[0].members
-    assert {"node_id": 7, "endpoint_id": 1} in members
+    assert {"node_id": 7, "endpoint_id": 1} in (await get_groups(demo_hass))[0].members
 
     remove = await remove_from_group(demo_hass, 1, node_id=7, endpoint_id=1)
     assert remove.success is True
@@ -142,7 +180,7 @@ async def test_demo_add_and_remove_member(demo_hass):
 
 
 @pytest.mark.asyncio
-async def test_demo_member_ops_on_missing_group_report_not_found(demo_hass):
+async def test_demo_member_ops_on_missing_group(demo_hass):
     add = await add_to_group(demo_hass, 999, 5, 1)
     assert add.success is False
     assert add.error_code == GROUP_NOT_FOUND_CODE
@@ -154,6 +192,12 @@ async def test_demo_delete_group(demo_hass):
     assert result.success is True
     assert await get_groups(demo_hass) == []
 
-    missing = await delete_group(demo_hass, 1)
-    assert missing.success is False
-    assert missing.error_code == GROUP_NOT_FOUND_CODE
+
+@pytest.mark.asyncio
+async def test_result_to_dict_is_serializable(demo_hass):
+    result = await create_group(demo_hass, 5, "Bedroom")
+    assert result.to_dict() == {
+        "success": True,
+        "message": result.message,
+        "error_code": None,
+    }


### PR DESCRIPTION
## Context
Makes group membership real on a live fabric (was demo-only / not-supported). Builds on the group-key provisioning from #261 — `AddGroup` is rejected by devices without prior key material, so membership provisions the key first.

## Changes
- `groups.py` real path: create/delete/list operate on the persistent registry (Matter has no 'create group' command); `add_to_group` → provision group key (`group_keys`) → `Groups.AddGroup` → record membership; `remove_from_group` → `Groups.RemoveGroup`; `delete_group` best-effort RemoveGroups members.
- `group_store.get_group_store()`: cached, test-seedable GroupStore singleton on `hass.data`.

## Tests
`test_groups.py` — real-path registry CRUD + add/remove guard branches (missing group, client unavailable); demo coverage retained (14 tests). The on-device AddGroup/RemoveGroup path (chip-dependent) is covered by the **PR 8 integration test**.

> Stacked on #261.