### PR TITLE
feat(groups): wire groupcast binding provisioning end-to-end (8/N)

### DIFF
--- a/custom_components/matter_binding_helper/api.py
+++ b/custom_components/matter_binding_helper/api.py
@@ -949,6 +949,7 @@ def _serialize_value(value: Any) -> dict[str, Any]:
         vol.Optional("target_group_id"): vol.Coerce(int),
         vol.Optional("verify", default=True): bool,
         vol.Optional("provision_acl", default=True): bool,
+        vol.Optional("provision_group", default=True): bool,
     }
 )
 @websocket_api.async_response
@@ -976,6 +977,7 @@ async def ws_create_binding(
         target_group_id=msg.get("target_group_id"),
         verify=msg.get("verify", True),
         provision_acl=msg.get("provision_acl", True),
+        provision_group=msg.get("provision_group", True),
     )
     _LOGGER.info("ws_create_binding result: %s", result)
     if result.success:
@@ -1190,6 +1192,7 @@ async def ws_provision_acl_for_bindings(
         vol.Optional("cluster_id"): vol.Coerce(int),
         vol.Optional("verify", default=True): bool,
         vol.Optional("remove_acl", default=True): bool,
+        vol.Optional("remove_group", default=True): bool,
     }
 )
 @websocket_api.async_response
@@ -1217,6 +1220,7 @@ async def ws_delete_binding(
         cluster_id=msg.get("cluster_id"),
         verify=msg.get("verify", True),
         remove_acl=msg.get("remove_acl", True),
+        remove_group=msg.get("remove_group", True),
     )
     _LOGGER.info("ws_delete_binding result: %s", result)
     if result.success:

--- a/custom_components/matter_binding_helper/matter/bindings.py
+++ b/custom_components/matter_binding_helper/matter/bindings.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from ..const import CLUSTER_BINDING
 from .acl import provision_acl_for_binding, remove_acl_entry
 from .client import get_raw_matter_client
+from .groups import provision_group_for_binding, teardown_group_for_binding
 from .demo import (
     add_demo_binding,
     get_demo_bindings,
@@ -441,6 +442,7 @@ async def create_binding(
     target_group_id: int | None = None,
     verify: bool = True,
     provision_acl: bool = True,
+    provision_group: bool = True,
 ) -> BindingVerificationResult:
     """Create a new binding with optional verification and ACL provisioning.
 
@@ -454,6 +456,7 @@ async def create_binding(
         target_group_id: Target group ID (for group binding)
         verify: If True, verify the binding was created by reading back
         provision_acl: If True, provision ACL on target device (unicast only)
+        provision_group: If True, provision group key/ACL on members (group only)
 
     Returns:
         BindingVerificationResult with success/verification status
@@ -593,6 +596,28 @@ async def create_binding(
             else:
                 _LOGGER.info("create_binding: ACL provisioned successfully")
 
+        # Provision group key + ACL on members for a groupcast binding
+        elif provision_group and target_group_id is not None:
+            _LOGGER.info(
+                "create_binding: Provisioning groupcast binding source %s -> group %s",
+                source_node_id,
+                target_group_id,
+            )
+            group_result = await provision_group_for_binding(
+                hass=hass,
+                source_node_id=source_node_id,
+                group_id=target_group_id,
+                cluster_id=cluster_id,
+            )
+            if not group_result.success:
+                _LOGGER.warning(
+                    "create_binding: group provisioning failed: %s "
+                    "(binding was still created)",
+                    group_result.message,
+                )
+            else:
+                _LOGGER.info("create_binding: group binding provisioned successfully")
+
         # Verify the binding was created if requested
         if verify:
             _LOGGER.info("create_binding: Verifying binding was written to device...")
@@ -673,6 +698,7 @@ async def delete_binding(
     cluster_id: int | None = None,
     verify: bool = True,
     remove_acl: bool = True,
+    remove_group: bool = True,
 ) -> BindingVerificationResult:
     """Delete a binding with optional verification and ACL cleanup.
 
@@ -841,6 +867,28 @@ async def delete_binding(
                     )
                 else:
                     _LOGGER.info("delete_binding: ACL removed successfully")
+
+        # Tear down group-auth ACL for a deleted groupcast binding
+        elif remove_group and target_group_id is not None and deleted_bindings:
+            group_cluster_id = cluster_id or (
+                deleted_bindings[0].cluster_id if deleted_bindings else None
+            )
+            if group_cluster_id is not None:
+                _LOGGER.info(
+                    "delete_binding: Tearing down groupcast binding to group %s",
+                    target_group_id,
+                )
+                group_result = await teardown_group_for_binding(
+                    hass=hass,
+                    group_id=target_group_id,
+                    cluster_id=group_cluster_id,
+                )
+                if not group_result.success:
+                    _LOGGER.warning(
+                        "delete_binding: group teardown failed: %s "
+                        "(binding was still deleted)",
+                        group_result.message,
+                    )
 
         # Verify the binding was deleted if requested
         if verify:

--- a/custom_components/matter_binding_helper/matter/groups.py
+++ b/custom_components/matter_binding_helper/matter/groups.py
@@ -17,7 +17,8 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from ..const import CLUSTER_GROUPS
+from ..const import CLUSTER_GROUPS, EVENT_GROUP_PROGRESS
+from .acl import provision_group_acl, remove_group_acl
 from .client import get_raw_matter_client
 from .demo import (
     add_demo_group_member,
@@ -291,6 +292,127 @@ async def remove_from_group(
     )
 
 
+async def provision_group_for_binding(
+    hass: HomeAssistant,
+    source_node_id: int,
+    group_id: int,
+    cluster_id: int,
+) -> GroupOperationResult:
+    """Provision everything a groupcast binding A -> Group G needs to function.
+
+    - Source A gets the group key so it can *send* encrypted groupcast.
+    - Each member gets the group key (idempotent) and a group-auth ACL granting
+      the group operate access to ``cluster_id`` so it *accepts* the commands.
+
+    Group membership (Groups.AddGroup) is established when members are added via
+    add_to_group; this focuses on the binding/cluster-specific provisioning.
+    """
+    if is_demo_mode(hass):
+        return GroupOperationResult(
+            success=True, message="Demo mode: group binding provisioned"
+        )
+
+    store = get_group_store(hass)
+    await store.async_load()
+    record = store.get_group(group_id)
+    if record is None:
+        return GroupOperationResult(
+            success=False,
+            message=f"Group {group_id} not found",
+            error_code=GROUP_NOT_FOUND_CODE,
+        )
+
+    def _progress(status: str, message: str) -> None:
+        hass.bus.async_fire(
+            EVENT_GROUP_PROGRESS,
+            {
+                "group_id": group_id,
+                "source_node_id": source_node_id,
+                "cluster_id": cluster_id,
+                "status": status,
+                "message": message,
+            },
+        )
+
+    _progress("provisioning", "Provisioning group key on source...")
+
+    # Source needs the group key to send groupcast.
+    key_result = await provision_group_key(
+        hass, source_node_id, group_id, record.key_set_id, record.epoch_key
+    )
+    if not key_result.success:
+        _progress("failed", key_result.message)
+        return key_result
+
+    # Each member needs the key (idempotent) and a group-auth ACL for the cluster.
+    failures: list[str] = []
+    for member in record.members:
+        node_id = member["node_id"]
+        endpoint_id = member["endpoint_id"]
+
+        member_key = await provision_group_key(
+            hass, node_id, group_id, record.key_set_id, record.epoch_key
+        )
+        if not member_key.success:
+            failures.append(f"node {node_id} key: {member_key.message}")
+            continue
+
+        acl_result = await provision_group_acl(
+            hass, node_id, group_id, cluster_id, endpoint_id
+        )
+        if not acl_result.success:
+            failures.append(f"node {node_id} ACL: {acl_result.message}")
+
+    if failures:
+        msg = "; ".join(failures)
+        _progress("failed", msg)
+        return GroupOperationResult(
+            success=False, message=msg, error_code=GROUP_DEVICE_ERROR_CODE
+        )
+
+    _progress("success", "Group binding provisioned")
+    return GroupOperationResult(
+        success=True,
+        message=f"Provisioned groupcast binding to group {group_id}",
+    )
+
+
+async def teardown_group_for_binding(
+    hass: HomeAssistant,
+    group_id: int,
+    cluster_id: int,
+) -> GroupOperationResult:
+    """Remove the per-member group-auth ACL for a deleted groupcast binding.
+
+    Conservative: removes only the cluster ACL this binding added. Group key
+    material and Groups.AddGroup membership are left intact (removed only when the
+    group itself is deleted), so other bindings to the same group keep working.
+    """
+    if is_demo_mode(hass):
+        return GroupOperationResult(success=True, message="Demo mode: teardown")
+
+    store = get_group_store(hass)
+    await store.async_load()
+    record = store.get_group(group_id)
+    if record is None:
+        return GroupOperationResult(
+            success=True, message=f"Group {group_id} not found; nothing to tear down"
+        )
+
+    for member in record.members:
+        result = await remove_group_acl(hass, member["node_id"], group_id, cluster_id)
+        if not result.success:
+            _LOGGER.warning(
+                "teardown_group_for_binding: ACL removal failed on node %s: %s",
+                member["node_id"],
+                result.message,
+            )
+
+    return GroupOperationResult(
+        success=True, message=f"Tore down groupcast binding to group {group_id}"
+    )
+
+
 # CLUSTER_GROUPS is re-exported for callers that need the Groups cluster id.
 __all__ = [
     "CLUSTER_GROUPS",
@@ -298,5 +420,7 @@ __all__ = [
     "create_group",
     "delete_group",
     "get_groups",
+    "provision_group_for_binding",
     "remove_from_group",
+    "teardown_group_for_binding",
 ]

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,0 +1,128 @@
+"""Group management integration tests for Matter Binding Helper.
+
+These exercise the WebSocket API end-to-end (api.py -> matter_client -> groups.py)
+against the testcontainers HA instance.
+
+IMPORTANT — coverage scope:
+    The Docker harness runs in DEMO mode because real Matter commissioning does
+    not work inside the Docker network (mDNS limitation; see conftest ha_config).
+    So these tests validate the WS command surface and the demo backend, NOT real
+    on-device provisioning (KeySetWrite / AddGroup / group-auth ACL / actuation).
+
+    Real device provisioning is exercised by:
+      - unit tests (orchestration with mocked device I/O), and
+      - manual validation against a real fabric via matter.sh.
+    The rs-matter mock devices now expose the Groups cluster (cluster 0x0004), so
+    a future mDNS-capable harness could assert real groupcast actuation.
+"""
+
+import pytest
+
+from .conftest import (
+    CLUSTER_ON_OFF,
+    ON_OFF_SWITCH_NODE_ID,
+)
+
+
+@pytest.mark.asyncio
+async def test_list_groups_returns_list(ws_client):
+    """list_groups returns a groups list (demo mode ships a seed group)."""
+    result = await ws_client.call("matter_binding_helper/list_groups")
+    assert "groups" in result
+    assert isinstance(result["groups"], list)
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_group(ws_client):
+    """A created group appears in the list."""
+    await ws_client.call(
+        "matter_binding_helper/create_group", group_id=200, name="Test Group"
+    )
+    result = await ws_client.call("matter_binding_helper/list_groups")
+    ids = {g["group_id"] for g in result["groups"]}
+    assert 200 in ids
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_group_errors(ws_client):
+    """Creating the same group twice surfaces a structured error."""
+    await ws_client.call("matter_binding_helper/create_group", group_id=201, name="Dup")
+    with pytest.raises(Exception):
+        await ws_client.call(
+            "matter_binding_helper/create_group", group_id=201, name="Dup"
+        )
+
+
+@pytest.mark.asyncio
+async def test_add_and_remove_member(ws_client):
+    """Members can be added to and removed from a group."""
+    await ws_client.call(
+        "matter_binding_helper/create_group", group_id=202, name="Members"
+    )
+    await ws_client.call(
+        "matter_binding_helper/add_to_group",
+        group_id=202,
+        node_id=ON_OFF_SWITCH_NODE_ID,
+        endpoint_id=1,
+    )
+
+    result = await ws_client.call("matter_binding_helper/list_groups")
+    group = next(g for g in result["groups"] if g["group_id"] == 202)
+    assert {"node_id": ON_OFF_SWITCH_NODE_ID, "endpoint_id": 1} in group["members"]
+
+    await ws_client.call(
+        "matter_binding_helper/remove_from_group",
+        group_id=202,
+        node_id=ON_OFF_SWITCH_NODE_ID,
+        endpoint_id=1,
+    )
+    result = await ws_client.call("matter_binding_helper/list_groups")
+    group = next(g for g in result["groups"] if g["group_id"] == 202)
+    assert {"node_id": ON_OFF_SWITCH_NODE_ID, "endpoint_id": 1} not in group["members"]
+
+
+@pytest.mark.asyncio
+async def test_delete_group(ws_client):
+    """A deleted group disappears from the list."""
+    await ws_client.call(
+        "matter_binding_helper/create_group", group_id=203, name="Doomed"
+    )
+    await ws_client.call("matter_binding_helper/delete_group", group_id=203)
+    result = await ws_client.call("matter_binding_helper/list_groups")
+    ids = {g["group_id"] for g in result["groups"]}
+    assert 203 not in ids
+
+
+@pytest.mark.asyncio
+async def test_create_groupcast_binding(ws_client):
+    """A groupcast binding (source -> group) can be created via the WS API."""
+    await ws_client.call(
+        "matter_binding_helper/create_group", group_id=204, name="Bind Target"
+    )
+    result = await ws_client.call(
+        "matter_binding_helper/create_binding",
+        source_node_id=ON_OFF_SWITCH_NODE_ID,
+        source_endpoint_id=1,
+        cluster_id=CLUSTER_ON_OFF,
+        target_group_id=204,
+    )
+    assert result.get("success"), f"Group binding create failed: {result}"
+
+    # The binding shows a group target in the list.
+    listing = await ws_client.call(
+        "matter_binding_helper/list_bindings",
+        node_id=ON_OFF_SWITCH_NODE_ID,
+        endpoint_id=1,
+    )
+    assert any(b.get("target_group_id") == 204 for b in listing.get("bindings", [])), (
+        f"Group binding not found in list: {listing}"
+    )
+
+    # And it can be deleted again.
+    await ws_client.call(
+        "matter_binding_helper/delete_binding",
+        source_node_id=ON_OFF_SWITCH_NODE_ID,
+        source_endpoint_id=1,
+        cluster_id=CLUSTER_ON_OFF,
+        target_group_id=204,
+    )

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -8,7 +8,7 @@ Covers:
 """
 
 import itertools
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -21,8 +21,10 @@ from custom_components.matter_binding_helper.matter.groups import (
     create_group,
     delete_group,
     get_groups,
+    provision_group_for_binding,
     remove_from_group,
 )
+from custom_components.matter_binding_helper.matter.models import GroupOperationResult
 from custom_components.matter_binding_helper.matter.group_store import (
     _GROUP_STORE_KEY,
     GroupStore,
@@ -129,6 +131,75 @@ async def test_real_remove_client_unavailable(hass):
         result = await remove_from_group(hass, 10, 5, 1)
     assert result.success is False
     assert result.error_code == "client_unavailable"
+
+
+# --- Groupcast binding orchestration (provision_group_for_binding) ---------
+
+
+@pytest.mark.asyncio
+async def test_provision_for_binding_missing_group(hass):
+    result = await provision_group_for_binding(
+        hass, source_node_id=4, group_id=99, cluster_id=6
+    )
+    assert result.success is False
+    assert result.error_code == GROUP_NOT_FOUND_CODE
+
+
+@pytest.mark.asyncio
+async def test_provision_for_binding_keys_source_and_acls_members(hass):
+    # Group 10 with two members.
+    await create_group(hass, 10, "Lights")
+    store = hass.data[DOMAIN]["_group_store"]
+    await store.async_add_member(10, 1, 1)
+    await store.async_add_member(10, 2, 1)
+
+    key_mock = AsyncMock(return_value=GroupOperationResult(True, "ok"))
+    acl_mock = AsyncMock(return_value=GroupOperationResult(True, "ok"))
+    with (
+        patch.object(groups, "provision_group_key", key_mock),
+        patch.object(groups, "provision_group_acl", acl_mock),
+    ):
+        result = await provision_group_for_binding(
+            hass, source_node_id=4, group_id=10, cluster_id=6
+        )
+
+    assert result.success is True
+    # Source (4) + both members (1, 2) get the key.
+    keyed_nodes = {call.args[1] for call in key_mock.await_args_list}
+    assert keyed_nodes == {4, 1, 2}
+    # Both members get a group ACL for the cluster.
+    acl_nodes = {call.args[1] for call in acl_mock.await_args_list}
+    assert acl_nodes == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_provision_for_binding_member_acl_failure_is_reported(hass):
+    await create_group(hass, 10, "Lights")
+    store = hass.data[DOMAIN]["_group_store"]
+    await store.async_add_member(10, 1, 1)
+
+    key_mock = AsyncMock(return_value=GroupOperationResult(True, "ok"))
+    acl_mock = AsyncMock(
+        return_value=GroupOperationResult(False, "denied", "device_error")
+    )
+    with (
+        patch.object(groups, "provision_group_key", key_mock),
+        patch.object(groups, "provision_group_acl", acl_mock),
+    ):
+        result = await provision_group_for_binding(
+            hass, source_node_id=4, group_id=10, cluster_id=6
+        )
+
+    assert result.success is False
+    assert "denied" in result.message
+
+
+@pytest.mark.asyncio
+async def test_provision_for_binding_demo_short_circuits(demo_hass):
+    result = await provision_group_for_binding(
+        demo_hass, source_node_id=4, group_id=1, cluster_id=6
+    )
+    assert result.success is True
 
 
 # --- Demo mode -------------------------------------------------------------


### PR DESCRIPTION
## Context
The keystone: creating a binding to a group now provisions the full chain so groupcast actually works; deleting it tears down the binding-specific ACL.

## Changes
- `groups.py`: `provision_group_for_binding()` keys the **source** (so it can send) and, per member, ensures the group key + a **group-auth ACL** for the cluster; fires `EVENT_GROUP_PROGRESS`. `teardown_group_for_binding()` removes the per-member cluster ACL (conservative — keeps keys/membership for other bindings to the same group).
- `bindings.py`: `create_binding`/`delete_binding` handle `target_group_id` via the group chain (gated on `provision_group`/`remove_group`), replacing the old skips.
- `api.py`: binding schemas accept `provision_group`/`remove_group`.

## Tests
- Unit: orchestration (source keyed + members ACL'd, partial-failure reporting, demo short-circuit) — 203 unit tests green.
- `tests/test_groups.py`: WS integration covering the command surface.

> ⚠️ **Integration-test scope:** the Docker harness runs in **demo mode** because real Matter commissioning fails inside Docker (mDNS — see `conftest.ha_config`). So real on-device provisioning (KeySetWrite/AddGroup/group ACL/actuation) is **not** auto-tested here; it's covered by unit tests (mocked device I/O) + manual `matter.sh` validation. The PR4 mock devices now expose the Groups cluster, so a future mDNS-capable harness could assert real actuation.

> Stacked on #263.