### PR TITLE
feat(groups): group management UI — create + delete (9/N)

### DIFF
--- a/frontend/src/components/dialogs/create-group-dialog.test.ts
+++ b/frontend/src/components/dialogs/create-group-dialog.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for CreateGroupDialog component.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { fixture, html } from "@open-wc/testing";
+import {
+  captureEvents,
+  elementUpdated,
+  queryShadow,
+  queryShadowAll,
+} from "../../test-utils";
+
+import "./create-group-dialog";
+import type { CreateGroupDialog } from "./create-group-dialog";
+
+describe("CreateGroupDialog", () => {
+  let element: CreateGroupDialog;
+
+  afterEach(() => {
+    element?.remove();
+  });
+
+  it("renders nothing when closed", async () => {
+    element = await fixture(html`<matter-create-group-dialog></matter-create-group-dialog>`);
+    expect(queryShadow(element, ".dialog-overlay")).toBeNull();
+  });
+
+  it("renders id and name inputs when open", async () => {
+    element = await fixture(
+      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
+    );
+    expect(queryShadow(element, "#group-id")).not.toBeNull();
+    expect(queryShadow(element, "#group-name")).not.toBeNull();
+  });
+
+  it("emits create-group with parsed id and trimmed name", async () => {
+    element = await fixture(
+      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
+    );
+    const { events } = captureEvents(element, "create-group");
+
+    const idInput = queryShadow<HTMLInputElement>(element, "#group-id");
+    const nameInput = queryShadow<HTMLInputElement>(element, "#group-name");
+    idInput!.value = "7";
+    idInput!.dispatchEvent(new Event("input"));
+    nameInput!.value = "  Bedroom  ";
+    nameInput!.dispatchEvent(new Event("input"));
+    await elementUpdated(element);
+
+    const buttons = queryShadowAll<HTMLButtonElement>(element, "button");
+    buttons.find((b) => b.textContent?.includes("Create"))!.click();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].detail).toEqual({ groupId: 7, name: "Bedroom" });
+  });
+
+  it("shows an error and emits nothing for an invalid id", async () => {
+    element = await fixture(
+      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
+    );
+    const { events } = captureEvents(element, "create-group");
+
+    const nameInput = queryShadow<HTMLInputElement>(element, "#group-name");
+    nameInput!.value = "Bedroom";
+    nameInput!.dispatchEvent(new Event("input"));
+    await elementUpdated(element);
+
+    const buttons = queryShadowAll<HTMLButtonElement>(element, "button");
+    buttons.find((b) => b.textContent?.includes("Create"))!.click();
+    await elementUpdated(element);
+
+    expect(events).toHaveLength(0);
+    expect(queryShadow(element, ".error")).not.toBeNull();
+  });
+
+  it("emits cancel when Cancel clicked", async () => {
+    element = await fixture(
+      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
+    );
+    const { events } = captureEvents(element, "cancel");
+
+    const buttons = queryShadowAll<HTMLButtonElement>(element, "button");
+    buttons.find((b) => b.textContent?.includes("Cancel"))!.click();
+
+    expect(events).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/dialogs/create-group-dialog.ts
+++ b/frontend/src/components/dialogs/create-group-dialog.ts
@@ -1,0 +1,175 @@
+/**
+ * CreateGroupDialog component
+ *
+ * Dialog for creating a new Matter group (group id + name).
+ */
+
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { buttonStyles, stateStyles } from "../../styles/shared-styles";
+import { dialogBaseStyles } from "../../styles/dialog-styles";
+
+/**
+ * Dialog to create a Matter group.
+ *
+ * @fires create-group - { groupId: number, name: string }
+ * @fires cancel - When cancelled
+ */
+@customElement("matter-create-group-dialog")
+export class CreateGroupDialog extends LitElement {
+  static styles = [
+    buttonStyles,
+    stateStyles,
+    dialogBaseStyles,
+    css`
+      :host {
+        display: contents;
+      }
+      .field {
+        margin-bottom: 16px;
+      }
+      label {
+        display: block;
+        font-size: 13px;
+        font-weight: 500;
+        margin-bottom: 4px;
+        color: var(--primary-text-color);
+      }
+      input {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 8px;
+        border: 1px solid var(--divider-color, #e0e0e0);
+        border-radius: 4px;
+        background: var(--card-background-color);
+        color: var(--primary-text-color);
+        font-size: 14px;
+      }
+      .error {
+        color: var(--error-color, #f44336);
+        font-size: 12px;
+        margin-top: 8px;
+      }
+    `,
+  ];
+
+  /** Whether the dialog is open */
+  @property({ type: Boolean })
+  open = false;
+
+  /** Whether an action is in progress */
+  @property({ type: Boolean })
+  loading = false;
+
+  @state() private _groupId = "";
+  @state() private _name = "";
+  @state() private _error = "";
+
+  render() {
+    if (!this.open) {
+      return nothing;
+    }
+
+    return html`
+      <div class="dialog-overlay" @click=${this._handleCancel}>
+        <div class="dialog" @click=${this._stop}>
+          <div class="dialog-header">Create Group</div>
+          <div class="dialog-body">
+            <div class="field">
+              <label for="group-id">Group ID</label>
+              <input
+                id="group-id"
+                type="number"
+                min="1"
+                .value=${this._groupId}
+                @input=${this._onGroupId}
+                ?disabled=${this.loading}
+                placeholder="e.g. 1"
+              />
+            </div>
+            <div class="field">
+              <label for="group-name">Name</label>
+              <input
+                id="group-name"
+                type="text"
+                .value=${this._name}
+                @input=${this._onName}
+                ?disabled=${this.loading}
+                placeholder="e.g. Living Room Lights"
+              />
+            </div>
+            ${this._error
+              ? html`<div class="error">${this._error}</div>`
+              : nothing}
+          </div>
+          <div class="dialog-actions">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              @click=${this._handleCancel}
+              ?disabled=${this.loading}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary ${this.loading ? "btn-loading" : ""}"
+              @click=${this._handleCreate}
+              ?disabled=${this.loading}
+            >
+              Create
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private _stop(e: Event) {
+    e.stopPropagation();
+  }
+
+  private _onGroupId(e: Event) {
+    this._groupId = (e.target as HTMLInputElement).value;
+    this._error = "";
+  }
+
+  private _onName(e: Event) {
+    this._name = (e.target as HTMLInputElement).value;
+    this._error = "";
+  }
+
+  private _handleCreate() {
+    const groupId = parseInt(this._groupId, 10);
+    if (!Number.isInteger(groupId) || groupId < 1) {
+      this._error = "Group ID must be a positive integer.";
+      return;
+    }
+    if (!this._name.trim()) {
+      this._error = "Name is required.";
+      return;
+    }
+    this.dispatchEvent(
+      new CustomEvent("create-group", {
+        detail: { groupId, name: this._name.trim() },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private _handleCancel() {
+    this._groupId = "";
+    this._name = "";
+    this._error = "";
+    this.dispatchEvent(
+      new CustomEvent("cancel", { bubbles: true, composed: true })
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "matter-create-group-dialog": CreateGroupDialog;
+  }
+}

--- a/frontend/src/components/groups/groups-tab.test.ts
+++ b/frontend/src/components/groups/groups-tab.test.ts
@@ -187,4 +187,36 @@ describe("GroupsTab", () => {
       expect(memberList).toBeFalsy();
     });
   });
+
+  describe("management actions", () => {
+    it("emits create-group-click when the Create Group button is clicked", async () => {
+      element = await fixture<GroupsTab>(html`
+        <matter-groups-tab .groups=${[]}></matter-groups-tab>
+      `);
+      const { events } = captureEvents(element, "create-group-click");
+
+      const buttons = queryShadowAll<HTMLButtonElement>(element, "button");
+      buttons.find((b) => b.textContent?.includes("Create Group"))!.click();
+
+      expect(events).toHaveLength(1);
+    });
+
+    it("emits delete-group (and not group-click) when Delete is clicked", async () => {
+      element = await fixture<GroupsTab>(html`
+        <matter-groups-tab .groups=${mockGroups}></matter-groups-tab>
+      `);
+      const del = captureEvents(element, "delete-group");
+      const click = captureEvents(element, "group-click");
+
+      const deleteBtn = queryShadowAll<HTMLButtonElement>(element, "button").find(
+        (b) => b.textContent?.includes("Delete")
+      );
+      deleteBtn!.click();
+
+      expect(del.events).toHaveLength(1);
+      expect((del.events[0] as CustomEvent).detail.group.group_id).toBe(1);
+      // stopPropagation prevents the card's group-click from firing.
+      expect(click.events).toHaveLength(0);
+    });
+  });
 });

--- a/frontend/src/components/groups/groups-tab.ts
+++ b/frontend/src/components/groups/groups-tab.ts
@@ -6,7 +6,7 @@
 
 import { LitElement, html, css } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { stateStyles } from "../../styles/shared-styles";
+import { stateStyles, buttonStyles } from "../../styles/shared-styles";
 import { baseCardStyles } from "../../styles/card-styles";
 import type { MatterGroup } from "../../types";
 
@@ -19,10 +19,33 @@ import type { MatterGroup } from "../../types";
 export class GroupsTab extends LitElement {
   static styles = [
     stateStyles,
+    buttonStyles,
     baseCardStyles,
     css`
       :host {
         display: block;
+      }
+
+      .card-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .group-card-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 8px;
+      }
+
+      .group-card-header .group-info {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .btn-delete-group {
+        flex-shrink: 0;
       }
 
       .binding-list {
@@ -84,14 +107,23 @@ export class GroupsTab extends LitElement {
   render() {
     return html`
       <div class="card">
-        <div class="card-header">Matter Groups</div>
+        <div class="card-header">
+          <span>Matter Groups</span>
+          <button
+            type="button"
+            class="btn btn-primary"
+            @click=${this._handleCreateClick}
+          >
+            Create Group
+          </button>
+        </div>
         ${this.loading
           ? html`<div class="loading">Loading...</div>`
           : this.groups.length > 0
             ? this._renderGroupList()
             : html`
                 <div class="empty-state">
-                  No Matter groups configured. Group management is coming soon.
+                  No Matter groups configured. Create one to get started.
                 </div>
               `}
       </div>
@@ -109,9 +141,20 @@ export class GroupsTab extends LitElement {
   private _renderGroup(group: MatterGroup) {
     return html`
       <div class="group-card" @click=${() => this._handleGroupClick(group)}>
-        <div class="group-name">${group.name}</div>
-        <div class="group-meta">
-          Group ID: ${group.group_id} | ${group.members.length} member(s)
+        <div class="group-card-header">
+          <div class="group-info">
+            <div class="group-name">${group.name}</div>
+            <div class="group-meta">
+              Group ID: ${group.group_id} | ${group.members.length} member(s)
+            </div>
+          </div>
+          <button
+            type="button"
+            class="btn btn-secondary btn-delete-group"
+            @click=${(e: Event) => this._handleDeleteClick(e, group)}
+          >
+            Delete
+          </button>
         </div>
         ${group.members.length > 0
           ? html`
@@ -132,6 +175,22 @@ export class GroupsTab extends LitElement {
 
   private _handleGroupClick(group: MatterGroup) {
     this.dispatchEvent(new CustomEvent("group-click", {
+      detail: { group },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  private _handleCreateClick() {
+    this.dispatchEvent(new CustomEvent("create-group-click", {
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  private _handleDeleteClick(e: Event, group: MatterGroup) {
+    e.stopPropagation();
+    this.dispatchEvent(new CustomEvent("delete-group", {
       detail: { group },
       bubbles: true,
       composed: true,

--- a/frontend/src/matter-binding-panel.ts
+++ b/frontend/src/matter-binding-panel.ts
@@ -36,6 +36,7 @@ import "./components/node-list/node-list";
 import "./components/bindings/binding-card";
 import "./components/acl/acl-section";
 import "./components/dialogs/create-binding-dialog";
+import "./components/dialogs/create-group-dialog";
 import "./components/dialogs/confirm-dialog";
 import "./components/dialogs/operation-progress-dialog";
 import "./components/dialogs/create-automation-dialog";
@@ -67,6 +68,7 @@ export class MatterBindingPanel extends LitElement {
   @state() private _error: string | null = null;
   @state() private _activeTab: "overview" | "bindings" | "groups" = "overview";
   @state() private _showCreateDialog = false;
+  @state() private _showCreateGroupDialog = false;
   @state() private _allBindings: BindingWithContext[] = [];
   @state() private _recommendations: BindingRecommendation[] = [];
   @state() private _overviewLoading = false;
@@ -701,6 +703,45 @@ export class MatterBindingPanel extends LitElement {
     console.log("Group clicked:", e.detail.group);
   }
 
+  private _openCreateGroupDialog(): void {
+    this._showCreateGroupDialog = true;
+  }
+
+  private _closeCreateGroupDialog(): void {
+    this._showCreateGroupDialog = false;
+  }
+
+  private async _handleCreateGroup(
+    e: CustomEvent<{ groupId: number; name: string }>
+  ): Promise<void> {
+    const { groupId, name } = e.detail;
+    this._actionInProgress = "create-group";
+    try {
+      await api.createGroup(this.hass, groupId, name);
+      this._showCreateGroupDialog = false;
+      await this._loadGroups();
+    } catch (err) {
+      this._error = `Failed to create group: ${this._extractErrorMessage(err)}`;
+    } finally {
+      this._actionInProgress = null;
+    }
+  }
+
+  private async _handleDeleteGroup(
+    e: CustomEvent<{ group: MatterGroup }>
+  ): Promise<void> {
+    const { group } = e.detail;
+    this._actionInProgress = "delete-group";
+    try {
+      await api.deleteGroup(this.hass, group.group_id);
+      await this._loadGroups();
+    } catch (err) {
+      this._error = `Failed to delete group: ${this._extractErrorMessage(err)}`;
+    } finally {
+      this._actionInProgress = null;
+    }
+  }
+
   private _confirmManualBinding(): void {
     if (!this._pendingManualBinding) return;
 
@@ -887,8 +928,16 @@ export class MatterBindingPanel extends LitElement {
                   .groups=${this._groups}
                   .loading=${this._loading}
                   @group-click=${this._handleGroupClick}
+                  @create-group-click=${this._openCreateGroupDialog}
+                  @delete-group=${this._handleDeleteGroup}
                 ></matter-groups-tab>
               `}
+        <matter-create-group-dialog
+          .open=${this._showCreateGroupDialog}
+          .loading=${this._actionInProgress !== null}
+          @create-group=${this._handleCreateGroup}
+          @cancel=${this._closeCreateGroupDialog}
+        ></matter-create-group-dialog>
         <matter-create-binding-dialog
           .open=${this._showCreateDialog}
           .sourceNode=${this._selectedSourceNode}


### PR DESCRIPTION
## Context
Turns the read-only 'coming soon' groups tab into working management, wired to the existing group WS API (functional in demo mode today; real fabric once the backend stack lands).

## Changes
- `create-group-dialog.ts`: Lit dialog for group id + name with validation.
- `groups-tab.ts`: 'Create Group' header action + per-group **Delete** button (stopPropagation so Delete doesn't trigger the card click); dropped 'coming soon' copy.
- `matter-binding-panel.ts`: create/delete handlers → `api.createGroup`/`deleteGroup` with reload + error surfacing.

## Tests
vitest: dialog (validation, create/cancel events) + groups-tab buttons (create-group-click, delete-group, no group-click leak). **Full frontend suite: 327 passed**; `npm run build` clean.

> Member add/remove UI follows in PR 10's scope. Stacked on #264.