### PR TITLE
feat(groups): group-target option in create-binding dialog (10/N)

### DIFF
--- a/frontend/src/components/dialogs/create-binding-dialog.test.ts
+++ b/frontend/src/components/dialogs/create-binding-dialog.test.ts
@@ -356,4 +356,62 @@ describe("CreateBindingDialog", () => {
       expect(text).toMatch(/can't control|no client/i);
     });
   });
+
+  describe("group target", () => {
+    const groups = [
+      { group_id: 5, name: "Living Room Lights", members: [] },
+      { group_id: 6, name: "Kitchen", members: [] },
+    ];
+
+    it("does not show the target-type toggle when no groups are available", async () => {
+      element = await fixture<CreateBindingDialog>(html`
+        <matter-create-binding-dialog
+          .open=${true}
+          .sourceNode=${sourceNode}
+          .sourceEndpoint=${sourceEndpoint}
+          .availableNodes=${targetNodes}
+        ></matter-create-binding-dialog>
+      `);
+      expect(queryShadow(element, "#targetType")).toBeNull();
+    });
+
+    it("shows the toggle and emits a group binding when group target is chosen", async () => {
+      element = await fixture<CreateBindingDialog>(html`
+        <matter-create-binding-dialog
+          .open=${true}
+          .sourceNode=${sourceNode}
+          .sourceEndpoint=${sourceEndpoint}
+          .availableNodes=${targetNodes}
+          .availableGroups=${groups}
+        ></matter-create-binding-dialog>
+      `);
+
+      const typeSelect = queryShadow<HTMLSelectElement>(element, "#targetType");
+      expect(typeSelect).not.toBeNull();
+      typeSelect!.value = "group";
+      typeSelect!.dispatchEvent(new Event("change"));
+      await elementUpdated(element);
+
+      const groupSelect = queryShadow<HTMLSelectElement>(element, "#targetGroup");
+      expect(groupSelect).not.toBeNull();
+      groupSelect!.value = "6";
+      groupSelect!.dispatchEvent(new Event("change"));
+      await elementUpdated(element);
+
+      const { events } = captureEvents<{
+        targetGroupId: number;
+        clusterId: number;
+      }>(element, "create-binding");
+
+      const submit = queryShadowAll<HTMLButtonElement>(element, "button").find(
+        (b) => b.textContent?.includes("Create Binding")
+      );
+      submit!.click();
+
+      expect(events).toHaveLength(1);
+      expect(events[0].detail.targetGroupId).toBe(6);
+      // Cluster defaults to the first source client cluster (On/Off).
+      expect(events[0].detail.clusterId).toBe(TEST_CLUSTERS.ON_OFF);
+    });
+  });
 });

--- a/frontend/src/components/dialogs/create-binding-dialog.ts
+++ b/frontend/src/components/dialogs/create-binding-dialog.ts
@@ -9,7 +9,7 @@ import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { buttonStyles, stateStyles, formStyles } from "../../styles/shared-styles";
 import { dialogBaseStyles } from "../../styles/dialog-styles";
-import type { MatterNode, MatterEndpoint } from "../../types";
+import type { MatterNode, MatterEndpoint, MatterGroup } from "../../types";
 import { getClusterName } from "../../types";
 
 /**
@@ -133,9 +133,21 @@ export class CreateBindingDialog extends LitElement {
   @property({ type: Boolean })
   loading = false;
 
+  /** Available Matter groups (enables the group-target option when non-empty) */
+  @property({ attribute: false })
+  availableGroups: MatterGroup[] = [];
+
   /** Internal state for selected cluster */
   @state()
   private _selectedClusterId: number | null = null;
+
+  /** Whether the binding targets a device or a group */
+  @state()
+  private _targetType: "device" | "group" = "device";
+
+  /** Selected group id (group target mode) */
+  @state()
+  private _selectedGroupId: number | null = null;
 
   render() {
     if (!this.open) {
@@ -174,12 +186,89 @@ export class CreateBindingDialog extends LitElement {
     return html`
       <div class="dialog-body">
         ${hasNoClientClusters ? this._renderNoClientClustersWarning() : nothing}
-        ${this._renderTargetNodeSelect()}
-        ${this.selectedTargetNodeId ? this._renderTargetEndpointSelect() : nothing}
-        ${this.selectedTargetNodeId && this.selectedTargetEndpointId
-          ? this._renderClusterSelect()
-          : nothing}
+        ${this.availableGroups.length > 0 ? this._renderTargetTypeToggle() : nothing}
+        ${this._targetType === "group"
+          ? this._renderGroupTarget()
+          : html`
+              ${this._renderTargetNodeSelect()}
+              ${this.selectedTargetNodeId
+                ? this._renderTargetEndpointSelect()
+                : nothing}
+              ${this.selectedTargetNodeId && this.selectedTargetEndpointId
+                ? this._renderClusterSelect()
+                : nothing}
+            `}
       </div>
+    `;
+  }
+
+  private _renderTargetTypeToggle() {
+    return html`
+      <div class="form-group">
+        <label for="targetType">Target Type</label>
+        <select
+          id="targetType"
+          name="targetType"
+          @change=${this._handleTargetTypeChange}
+          .value=${this._targetType}
+        >
+          <option value="device">Device (unicast)</option>
+          <option value="group">Group (groupcast)</option>
+        </select>
+      </div>
+    `;
+  }
+
+  private _renderGroupTarget() {
+    const sourceClientClusters = this.sourceEndpoint?.client_clusters ?? [];
+    if (this._selectedClusterId === null && sourceClientClusters.length > 0) {
+      this._selectedClusterId = sourceClientClusters[0];
+    }
+    return html`
+      <div class="form-group">
+        <label for="targetGroup">Target Group</label>
+        <select
+          id="targetGroup"
+          name="targetGroup"
+          required
+          @change=${this._handleTargetGroupChange}
+          .value=${this._selectedGroupId?.toString() ?? ""}
+        >
+          <option value="" disabled selected>Select a group...</option>
+          ${this.availableGroups.map(
+            (group) => html`
+              <option value=${group.group_id}>
+                ${group.name} (ID ${group.group_id})
+              </option>
+            `
+          )}
+        </select>
+      </div>
+      ${sourceClientClusters.length > 0
+        ? html`
+            <div class="form-group">
+              <label for="groupCluster">Cluster</label>
+              <select
+                id="groupCluster"
+                name="groupCluster"
+                required
+                @change=${this._handleClusterChange}
+                .value=${this._selectedClusterId?.toString() ?? ""}
+              >
+                ${sourceClientClusters.map(
+                  (clusterId) => html`
+                    <option value=${clusterId}>
+                      ${getClusterName(clusterId)}
+                    </option>
+                  `
+                )}
+              </select>
+              <div class="cluster-info">
+                The source will multicast this cluster's commands to the group.
+              </div>
+            </div>
+          `
+        : nothing}
     `;
   }
 
@@ -285,12 +374,14 @@ export class CreateBindingDialog extends LitElement {
   }
 
   private _renderActions() {
-    const compatibleClusters = this._getCompatibleClusters();
-    const canSubmit =
-      this.selectedTargetNodeId !== null &&
-      this.selectedTargetEndpointId !== null &&
-      compatibleClusters.length > 0 &&
-      !this.loading;
+    const canSubmit = this._targetType === "group"
+      ? this._selectedGroupId !== null &&
+        (this.sourceEndpoint?.client_clusters ?? []).length > 0 &&
+        !this.loading
+      : this.selectedTargetNodeId !== null &&
+        this.selectedTargetEndpointId !== null &&
+        this._getCompatibleClusters().length > 0 &&
+        !this.loading;
 
     return html`
       <div class="dialog-actions">
@@ -405,6 +496,21 @@ export class CreateBindingDialog extends LitElement {
   private _handleSubmit(e: Event) {
     e.preventDefault();
 
+    if (this._targetType === "group") {
+      const sourceClientClusters = this.sourceEndpoint?.client_clusters ?? [];
+      const clusterId = this._selectedClusterId ?? sourceClientClusters[0];
+      if (this._selectedGroupId !== null && clusterId !== undefined) {
+        this.dispatchEvent(
+          new CustomEvent("create-binding", {
+            detail: { targetGroupId: this._selectedGroupId, clusterId },
+            bubbles: true,
+            composed: true,
+          })
+        );
+      }
+      return;
+    }
+
     const compatibleClusters = this._getCompatibleClusters();
     const clusterId = this._selectedClusterId ?? compatibleClusters[0];
 
@@ -424,6 +530,18 @@ export class CreateBindingDialog extends LitElement {
           composed: true,
         })
       );
+    }
+  }
+
+  private _handleTargetTypeChange(e: Event) {
+    this._targetType = (e.target as HTMLSelectElement).value as "device" | "group";
+    this._selectedClusterId = null;
+  }
+
+  private _handleTargetGroupChange(e: Event) {
+    const groupId = parseInt((e.target as HTMLSelectElement).value, 10);
+    if (!isNaN(groupId)) {
+      this._selectedGroupId = groupId;
     }
   }
 

--- a/frontend/src/matter-binding-panel.ts
+++ b/frontend/src/matter-binding-panel.ts
@@ -672,10 +672,17 @@ export class MatterBindingPanel extends LitElement {
     this._selectedTargetEndpointId = e.detail.endpointId;
   }
 
-  private _handleCreateDialogCreateBinding(e: CustomEvent<{ targetNodeId: number; targetEndpointId: number; clusterId: number }>) {
-    const { targetNodeId, targetEndpointId, clusterId } = e.detail;
+  private _handleCreateDialogCreateBinding(e: CustomEvent<{ targetNodeId?: number; targetEndpointId?: number; targetGroupId?: number; clusterId: number }>) {
+    const { targetNodeId, targetEndpointId, targetGroupId, clusterId } = e.detail;
 
     if (!this._selectedSourceNode || !this._selectedSourceEndpoint) return;
+
+    // Group (groupcast) binding: no target node/endpoint — create directly.
+    if (targetGroupId !== undefined) {
+      this._showCreateDialog = false;
+      void this._createGroupBinding(targetGroupId, clusterId);
+      return;
+    }
 
     const targetNode = this._nodes.find((n) => n.node_id === targetNodeId);
     const targetEndpoint = targetNode?.endpoints.find((ep) => ep.endpoint_id === targetEndpointId);
@@ -696,6 +703,27 @@ export class MatterBindingPanel extends LitElement {
 
     // Close create dialog
     this._showCreateDialog = false;
+  }
+
+  private async _createGroupBinding(targetGroupId: number, clusterId: number): Promise<void> {
+    if (!this._selectedSourceNode || !this._selectedSourceEndpoint) return;
+    this._actionInProgress = "create-group-binding";
+    try {
+      await api.createBinding(
+        this.hass,
+        this._selectedSourceNode.node_id,
+        this._selectedSourceEndpoint.endpoint_id,
+        clusterId,
+        undefined,
+        undefined,
+        targetGroupId
+      );
+      await this._loadBindings();
+    } catch (err) {
+      this._error = `Failed to create group binding: ${this._extractErrorMessage(err)}`;
+    } finally {
+      this._actionInProgress = null;
+    }
   }
 
   private _handleGroupClick(e: CustomEvent<{ group: MatterGroup }>) {
@@ -943,6 +971,7 @@ export class MatterBindingPanel extends LitElement {
           .sourceNode=${this._selectedSourceNode}
           .sourceEndpoint=${this._selectedSourceEndpoint}
           .availableNodes=${this._nodes.filter((n) => n.node_id !== this._selectedSourceNode?.node_id)}
+          .availableGroups=${this._groups}
           .selectedTargetNodeId=${this._selectedTargetNodeId}
           .selectedTargetEndpointId=${this._selectedTargetEndpointId}
           .loading=${this._actionInProgress !== null}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -207,6 +207,7 @@ export interface ACLProgressEvent {
 
 // Event name constant
 export const EVENT_ACL_PROGRESS = "matter_binding_helper_acl_progress";
+export const EVENT_GROUP_PROGRESS = "matter_binding_helper_group_progress";
 
 export interface ProvisionACLForBindingsResponse {
   success: boolean;


### PR DESCRIPTION
## Context
Final piece: lets users create groupcast bindings (source → group) from the UI.

## Changes
- `create-binding-dialog.ts`: a **'Target Type: Device | Group'** toggle, shown only when groups are available (so the existing device flow + all current tests are unchanged). Group mode picks a group + a cluster from the source's client clusters and emits `create-binding` with `{ targetGroupId, clusterId }`.
- `matter-binding-panel.ts`: passes `availableGroups` to the dialog; group bindings bypass the unicast confirm/wizard flow and call `api.createBinding` directly with `targetGroupId`, then reload.
- `types.ts`: `EVENT_GROUP_PROGRESS` constant.

## Tests
vitest: toggle hidden without groups; group selection emits the right payload. **329 frontend tests green**; build clean.

> Stacked on #265. Completes the groupcast feature (PRs 1-10).