### PR TITLE
feat(groups): auto-allocate group IDs (better create-group UX)

### DIFF
--- a/custom_components/matter_binding_helper/api.py
+++ b/custom_components/matter_binding_helper/api.py
@@ -1252,7 +1252,7 @@ async def ws_list_groups(
 @websocket_api.websocket_command(
     {
         vol.Required("type"): WS_TYPE_CREATE_GROUP,
-        vol.Required("group_id"): vol.Coerce(int),
+        vol.Optional("group_id"): vol.Coerce(int),
         vol.Required("name"): str,
     }
 )
@@ -1262,10 +1262,12 @@ async def ws_create_group(
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Create a new Matter group."""
-    result = await matter_client.create_group(hass, msg["group_id"], msg["name"])
+    """Create a new Matter group. group_id is optional (auto-allocated if absent)."""
+    result = await matter_client.create_group(hass, msg.get("group_id"), msg["name"])
     if result.success:
-        connection.send_result(msg["id"], {"success": True})
+        connection.send_result(
+            msg["id"], {"success": True, "group_id": result.group_id}
+        )
     else:
         connection.send_error(
             msg["id"], result.error_code or "create_failed", result.message

--- a/custom_components/matter_binding_helper/const.py
+++ b/custom_components/matter_binding_helper/const.py
@@ -95,6 +95,9 @@ ACL_VERIFY_INTERVAL = 2  # seconds
 # group key sets are allocated from this base upward.
 GROUP_KEY_SET_BASE = 0x0100
 GROUP_KEY_SECURITY_POLICY_TRUST_FIRST = 0  # GroupKeySecurityPolicyEnum.kTrustFirst
+# Group ids are auto-allocated from this base. Matter reserves group id 0 ("all
+# groups"); the application range is 0x0001-0xFFF7.
+GROUP_ID_BASE = 1
 # GroupKeyManagement attribute IDs
 ATTR_GROUP_KEY_MAP = 0  # GroupKeyMap (list of GroupId -> GroupKeySetID)
 # epochStartTime0 must be non-zero per spec (and rs-matter rejects 0). The exact

--- a/custom_components/matter_binding_helper/matter/demo.py
+++ b/custom_components/matter_binding_helper/matter/demo.py
@@ -346,12 +346,18 @@ def get_demo_groups() -> list[GroupEntry]:
     return [_demo_groups[gid] for gid in sorted(_demo_groups)]
 
 
-def create_demo_group(group_id: int, name: str) -> bool:
-    """Create a demo group. Returns False if it already exists."""
-    if group_id in _demo_groups:
-        return False
+def create_demo_group(group_id: int | None, name: str) -> int | None:
+    """Create a demo group.
+
+    If ``group_id`` is None, allocate the next free id. Returns the created group
+    id, or None if an explicitly-requested id already exists.
+    """
+    if group_id is None:
+        group_id = (max(_demo_groups) + 1) if _demo_groups else 1
+    elif group_id in _demo_groups:
+        return None
     _demo_groups[group_id] = GroupEntry(group_id=group_id, name=name, members=[])
-    return True
+    return group_id
 
 
 def delete_demo_group(group_id: int) -> bool:

--- a/custom_components/matter_binding_helper/matter/group_store.py
+++ b/custom_components/matter_binding_helper/matter/group_store.py
@@ -25,7 +25,7 @@ from typing import Any, Callable
 
 from homeassistant.core import HomeAssistant
 
-from ..const import DOMAIN, GROUP_KEY_SET_BASE
+from ..const import DOMAIN, GROUP_ID_BASE, GROUP_KEY_SET_BASE
 
 
 def get_group_store(hass: HomeAssistant) -> "GroupStore":
@@ -128,10 +128,15 @@ class GroupStore:
             return
         raw = await self._store.async_load()
         if not raw:
-            self._data = {"next_key_set_id": GROUP_KEY_SET_BASE, "groups": {}}
+            self._data = {
+                "next_key_set_id": GROUP_KEY_SET_BASE,
+                "next_group_id": GROUP_ID_BASE,
+                "groups": {},
+            }
         else:
             self._data = {
                 "next_key_set_id": int(raw.get("next_key_set_id", GROUP_KEY_SET_BASE)),
+                "next_group_id": int(raw.get("next_group_id", GROUP_ID_BASE)),
                 "groups": dict(raw.get("groups", {})),
             }
 
@@ -159,16 +164,29 @@ class GroupStore:
 
     # -- mutations --------------------------------------------------------
 
-    async def async_create_group(self, group_id: int, name: str) -> GroupRecord:
+    def _allocate_group_id(self, data: dict[str, Any]) -> int:
+        """Pick the next free group id, skipping any already in use."""
+        gid = int(data.get("next_group_id", GROUP_ID_BASE))
+        while str(gid) in data["groups"]:
+            gid += 1
+        data["next_group_id"] = gid + 1
+        return gid
+
+    async def async_create_group(self, group_id: int | None, name: str) -> GroupRecord:
         """Create a group, allocating a key set id and a fresh epoch key.
 
-        Raises ValueError if the group already exists.
+        If ``group_id`` is None, the next free group id is allocated automatically
+        (the common case — users shouldn't have to invent a Matter group id).
+        Raises ValueError if an explicitly-requested group already exists.
         """
         data = self._require_loaded()
-        key = str(group_id)
-        if key in data["groups"]:
+
+        if group_id is None:
+            group_id = self._allocate_group_id(data)
+        elif str(group_id) in data["groups"]:
             raise ValueError(f"Group {group_id} already exists")
 
+        key = str(group_id)
         key_set_id = int(data["next_key_set_id"])
         data["next_key_set_id"] = key_set_id + 1
         record = GroupRecord(

--- a/custom_components/matter_binding_helper/matter/groups.py
+++ b/custom_components/matter_binding_helper/matter/groups.py
@@ -94,28 +94,39 @@ async def get_groups(hass: HomeAssistant) -> list[GroupEntry]:
 
 
 async def create_group(
-    hass: HomeAssistant, group_id: int, name: str
+    hass: HomeAssistant, group_id: int | None, name: str
 ) -> GroupOperationResult:
-    """Create a new Matter group (allocates a group key set in the registry)."""
+    """Create a new Matter group (allocates a group key set in the registry).
+
+    ``group_id`` is optional; when None the next free id is allocated so users
+    don't have to invent a Matter group id.
+    """
     if is_demo_mode(hass):
-        if not create_demo_group(group_id, name):
+        assigned = create_demo_group(group_id, name)
+        if assigned is None:
             return GroupOperationResult(
                 success=False,
                 message=f"Group {group_id} already exists",
                 error_code=GROUP_ALREADY_EXISTS_CODE,
             )
-        return GroupOperationResult(success=True, message=f"Created group {group_id}")
+        return GroupOperationResult(
+            success=True, message=f"Created group {assigned}", group_id=assigned
+        )
 
     store = get_group_store(hass)
     await store.async_load()
-    if store.get_group(group_id) is not None:
+    if group_id is not None and store.get_group(group_id) is not None:
         return GroupOperationResult(
             success=False,
             message=f"Group {group_id} already exists",
             error_code=GROUP_ALREADY_EXISTS_CODE,
         )
-    await store.async_create_group(group_id, name)
-    return GroupOperationResult(success=True, message=f"Created group {group_id}")
+    record = await store.async_create_group(group_id, name)
+    return GroupOperationResult(
+        success=True,
+        message=f"Created group {record.group_id}",
+        group_id=record.group_id,
+    )
 
 
 async def delete_group(hass: HomeAssistant, group_id: int) -> GroupOperationResult:

--- a/custom_components/matter_binding_helper/matter/models.py
+++ b/custom_components/matter_binding_helper/matter/models.py
@@ -153,6 +153,7 @@ class GroupOperationResult:
     success: bool
     message: str
     error_code: str | None = None
+    group_id: int | None = None  # the (possibly auto-allocated) group id
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
@@ -160,6 +161,7 @@ class GroupOperationResult:
             "success": self.success,
             "message": self.message,
             "error_code": self.error_code,
+            "group_id": self.group_id,
         }
 
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -198,13 +198,13 @@ export async function listGroups(hass: HomeAssistant): Promise<ListGroupsRespons
 
 export async function createGroup(
   hass: HomeAssistant,
-  groupId: number,
-  name: string
+  name: string,
+  groupId?: number
 ): Promise<SuccessResponse> {
   return hass.callWS({
     type: `${DOMAIN}/create_group`,
-    group_id: groupId,
     name,
+    ...(groupId !== undefined ? { group_id: groupId } : {}),
   });
 }
 

--- a/frontend/src/components/dialogs/create-group-dialog.test.ts
+++ b/frontend/src/components/dialogs/create-group-dialog.test.ts
@@ -26,24 +26,21 @@ describe("CreateGroupDialog", () => {
     expect(queryShadow(element, ".dialog-overlay")).toBeNull();
   });
 
-  it("renders id and name inputs when open", async () => {
+  it("renders only a name input when open (id is auto-allocated)", async () => {
     element = await fixture(
       html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
     );
-    expect(queryShadow(element, "#group-id")).not.toBeNull();
+    expect(queryShadow(element, "#group-id")).toBeNull();
     expect(queryShadow(element, "#group-name")).not.toBeNull();
   });
 
-  it("emits create-group with parsed id and trimmed name", async () => {
+  it("emits create-group with just the trimmed name", async () => {
     element = await fixture(
       html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
     );
     const { events } = captureEvents(element, "create-group");
 
-    const idInput = queryShadow<HTMLInputElement>(element, "#group-id");
     const nameInput = queryShadow<HTMLInputElement>(element, "#group-name");
-    idInput!.value = "7";
-    idInput!.dispatchEvent(new Event("input"));
     nameInput!.value = "  Bedroom  ";
     nameInput!.dispatchEvent(new Event("input"));
     await elementUpdated(element);
@@ -52,19 +49,14 @@ describe("CreateGroupDialog", () => {
     buttons.find((b) => b.textContent?.includes("Create"))!.click();
 
     expect(events).toHaveLength(1);
-    expect(events[0].detail).toEqual({ groupId: 7, name: "Bedroom" });
+    expect(events[0].detail).toEqual({ name: "Bedroom" });
   });
 
-  it("shows an error and emits nothing for an invalid id", async () => {
+  it("shows an error and emits nothing for an empty name", async () => {
     element = await fixture(
       html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
     );
     const { events } = captureEvents(element, "create-group");
-
-    const nameInput = queryShadow<HTMLInputElement>(element, "#group-name");
-    nameInput!.value = "Bedroom";
-    nameInput!.dispatchEvent(new Event("input"));
-    await elementUpdated(element);
 
     const buttons = queryShadowAll<HTMLButtonElement>(element, "button");
     buttons.find((b) => b.textContent?.includes("Create"))!.click();

--- a/frontend/src/components/dialogs/create-group-dialog.test.ts
+++ b/frontend/src/components/dialogs/create-group-dialog.test.ts
@@ -66,6 +66,86 @@ describe("CreateGroupDialog", () => {
     expect(queryShadow(element, ".error")).not.toBeNull();
   });
 
+  it("hides the group-id field until Advanced is checked", async () => {
+    element = await fixture(
+      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
+    );
+    expect(queryShadow(element, "#group-id")).toBeNull();
+
+    const advanced = queryShadow<HTMLInputElement>(
+      element,
+      ".advanced-toggle input"
+    );
+    advanced!.checked = true;
+    advanced!.dispatchEvent(new Event("change"));
+    await elementUpdated(element);
+
+    expect(queryShadow(element, "#group-id")).not.toBeNull();
+    expect(queryShadow(element, ".note")).not.toBeNull();
+  });
+
+  it("emits the manual id when Advanced is set with a valid id", async () => {
+    element = await fixture(
+      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
+    );
+    const { events } = captureEvents(element, "create-group");
+
+    const nameInput = queryShadow<HTMLInputElement>(element, "#group-name");
+    nameInput!.value = "Bedroom";
+    nameInput!.dispatchEvent(new Event("input"));
+
+    const advanced = queryShadow<HTMLInputElement>(
+      element,
+      ".advanced-toggle input"
+    );
+    advanced!.checked = true;
+    advanced!.dispatchEvent(new Event("change"));
+    await elementUpdated(element);
+
+    const idInput = queryShadow<HTMLInputElement>(element, "#group-id");
+    idInput!.value = "100";
+    idInput!.dispatchEvent(new Event("input"));
+    await elementUpdated(element);
+
+    const buttons = queryShadowAll<HTMLButtonElement>(element, "button");
+    buttons.find((b) => b.textContent?.includes("Create"))!.click();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].detail).toEqual({ name: "Bedroom", groupId: 100 });
+  });
+
+  it("rejects an out-of-range manual id", async () => {
+    element = await fixture(
+      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
+    );
+    const { events } = captureEvents(element, "create-group");
+
+    const nameInput = queryShadow<HTMLInputElement>(element, "#group-name");
+    nameInput!.value = "Bedroom";
+    nameInput!.dispatchEvent(new Event("input"));
+
+    const advanced = queryShadow<HTMLInputElement>(
+      element,
+      ".advanced-toggle input"
+    );
+    advanced!.checked = true;
+    advanced!.dispatchEvent(new Event("change"));
+    await elementUpdated(element);
+
+    const idInput = queryShadow<HTMLInputElement>(element, "#group-id");
+    idInput!.value = "99999";
+    idInput!.dispatchEvent(new Event("input"));
+    await elementUpdated(element);
+
+    queryShadowAll<HTMLButtonElement>(element, "button")
+      .find((b) => b.textContent?.includes("Create"))!
+      .click();
+    await elementUpdated(element);
+
+    expect(events).toHaveLength(0);
+    expect(queryShadow(element, ".error")).not.toBeNull();
+  });
+
   it("emits cancel when Cancel clicked", async () => {
     element = await fixture(
       html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`

--- a/frontend/src/components/dialogs/create-group-dialog.ts
+++ b/frontend/src/components/dialogs/create-group-dialog.ts
@@ -50,6 +50,23 @@ export class CreateGroupDialog extends LitElement {
         font-size: 12px;
         margin-top: 8px;
       }
+      .advanced-toggle {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 400;
+        cursor: pointer;
+        margin-bottom: 12px;
+      }
+      .advanced-toggle input {
+        width: auto;
+      }
+      .note {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+        margin-top: 6px;
+        line-height: 1.4;
+      }
     `,
   ];
 
@@ -63,6 +80,8 @@ export class CreateGroupDialog extends LitElement {
 
   @state() private _name = "";
   @state() private _error = "";
+  @state() private _advanced = false;
+  @state() private _groupId = "";
 
   render() {
     if (!this.open) {
@@ -85,6 +104,37 @@ export class CreateGroupDialog extends LitElement {
                 placeholder="e.g. Living Room Lights"
               />
             </div>
+            <label class="advanced-toggle">
+              <input
+                type="checkbox"
+                .checked=${this._advanced}
+                @change=${this._onAdvancedToggle}
+                ?disabled=${this.loading}
+              />
+              Advanced: set group ID manually
+            </label>
+            ${this._advanced
+              ? html`
+                  <div class="field">
+                    <label for="group-id">Group ID</label>
+                    <input
+                      id="group-id"
+                      type="number"
+                      min="1"
+                      max="65527"
+                      .value=${this._groupId}
+                      @input=${this._onGroupId}
+                      ?disabled=${this.loading}
+                      placeholder="e.g. 100"
+                    />
+                    <div class="note">
+                      Leave Advanced off to let Home Assistant pick a free ID
+                      automatically. Only set this if you need to match a specific
+                      Matter group ID (1–65527); it must not already be in use.
+                    </div>
+                  </div>
+                `
+              : nothing}
             ${this._error
               ? html`<div class="error">${this._error}</div>`
               : nothing}
@@ -121,14 +171,38 @@ export class CreateGroupDialog extends LitElement {
     this._error = "";
   }
 
+  private _onAdvancedToggle(e: Event) {
+    this._advanced = (e.target as HTMLInputElement).checked;
+    this._error = "";
+  }
+
+  private _onGroupId(e: Event) {
+    this._groupId = (e.target as HTMLInputElement).value;
+    this._error = "";
+  }
+
   private _handleCreate() {
     if (!this._name.trim()) {
       this._error = "Name is required.";
       return;
     }
+
+    const detail: { name: string; groupId?: number } = {
+      name: this._name.trim(),
+    };
+
+    if (this._advanced && this._groupId.trim() !== "") {
+      const groupId = parseInt(this._groupId, 10);
+      if (!Number.isInteger(groupId) || groupId < 1 || groupId > 65527) {
+        this._error = "Group ID must be a whole number between 1 and 65527.";
+        return;
+      }
+      detail.groupId = groupId;
+    }
+
     this.dispatchEvent(
       new CustomEvent("create-group", {
-        detail: { name: this._name.trim() },
+        detail,
         bubbles: true,
         composed: true,
       })
@@ -137,6 +211,8 @@ export class CreateGroupDialog extends LitElement {
 
   private _handleCancel() {
     this._name = "";
+    this._groupId = "";
+    this._advanced = false;
     this._error = "";
     this.dispatchEvent(
       new CustomEvent("cancel", { bubbles: true, composed: true })

--- a/frontend/src/components/dialogs/create-group-dialog.ts
+++ b/frontend/src/components/dialogs/create-group-dialog.ts
@@ -61,7 +61,6 @@ export class CreateGroupDialog extends LitElement {
   @property({ type: Boolean })
   loading = false;
 
-  @state() private _groupId = "";
   @state() private _name = "";
   @state() private _error = "";
 
@@ -75,18 +74,6 @@ export class CreateGroupDialog extends LitElement {
         <div class="dialog" @click=${this._stop}>
           <div class="dialog-header">Create Group</div>
           <div class="dialog-body">
-            <div class="field">
-              <label for="group-id">Group ID</label>
-              <input
-                id="group-id"
-                type="number"
-                min="1"
-                .value=${this._groupId}
-                @input=${this._onGroupId}
-                ?disabled=${this.loading}
-                placeholder="e.g. 1"
-              />
-            </div>
             <div class="field">
               <label for="group-name">Name</label>
               <input
@@ -129,29 +116,19 @@ export class CreateGroupDialog extends LitElement {
     e.stopPropagation();
   }
 
-  private _onGroupId(e: Event) {
-    this._groupId = (e.target as HTMLInputElement).value;
-    this._error = "";
-  }
-
   private _onName(e: Event) {
     this._name = (e.target as HTMLInputElement).value;
     this._error = "";
   }
 
   private _handleCreate() {
-    const groupId = parseInt(this._groupId, 10);
-    if (!Number.isInteger(groupId) || groupId < 1) {
-      this._error = "Group ID must be a positive integer.";
-      return;
-    }
     if (!this._name.trim()) {
       this._error = "Name is required.";
       return;
     }
     this.dispatchEvent(
       new CustomEvent("create-group", {
-        detail: { groupId, name: this._name.trim() },
+        detail: { name: this._name.trim() },
         bubbles: true,
         composed: true,
       })
@@ -159,7 +136,6 @@ export class CreateGroupDialog extends LitElement {
   }
 
   private _handleCancel() {
-    this._groupId = "";
     this._name = "";
     this._error = "";
     this.dispatchEvent(

--- a/frontend/src/matter-binding-panel.ts
+++ b/frontend/src/matter-binding-panel.ts
@@ -740,12 +740,12 @@ export class MatterBindingPanel extends LitElement {
   }
 
   private async _handleCreateGroup(
-    e: CustomEvent<{ groupId: number; name: string }>
+    e: CustomEvent<{ name: string }>
   ): Promise<void> {
-    const { groupId, name } = e.detail;
+    const { name } = e.detail;
     this._actionInProgress = "create-group";
     try {
-      await api.createGroup(this.hass, groupId, name);
+      await api.createGroup(this.hass, name);
       this._showCreateGroupDialog = false;
       await this._loadGroups();
     } catch (err) {

--- a/frontend/src/matter-binding-panel.ts
+++ b/frontend/src/matter-binding-panel.ts
@@ -740,12 +740,12 @@ export class MatterBindingPanel extends LitElement {
   }
 
   private async _handleCreateGroup(
-    e: CustomEvent<{ name: string }>
+    e: CustomEvent<{ name: string; groupId?: number }>
   ): Promise<void> {
-    const { name } = e.detail;
+    const { name, groupId } = e.detail;
     this._actionInProgress = "create-group";
     try {
-      await api.createGroup(this.hass, name);
+      await api.createGroup(this.hass, name, groupId);
       this._showCreateGroupDialog = false;
       await this._loadGroups();
     } catch (err) {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,7 +4,6 @@ Mocks homeassistant modules to allow testing matter/ subpackage in isolation.
 """
 
 import sys
-from types import ModuleType
 from unittest.mock import MagicMock
 
 # Create mock module for homeassistant with all submodules

--- a/tests/unit/test_bindings_parsing.py
+++ b/tests/unit/test_bindings_parsing.py
@@ -4,9 +4,6 @@ Tests that bindings with cluster_id=None (any cluster per Matter spec)
 are handled correctly without causing TypeError.
 """
 
-import pytest
-
-from custom_components.matter_binding_helper.matter.models import BindingEntry
 from custom_components.matter_binding_helper.matter.bindings import (
     _parse_binding_value,
 )
@@ -24,7 +21,9 @@ class TestParseBindingValueNoneCluster:
                 "Cluster": None,  # Explicitly None
             }
         ]
-        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+        result = _parse_binding_value(
+            node_id=1, endpoint_id=1, binding_value=binding_value
+        )
 
         assert len(result) == 1
         assert result[0].cluster_id is None
@@ -40,7 +39,9 @@ class TestParseBindingValueNoneCluster:
                 # No Cluster key at all
             }
         ]
-        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+        result = _parse_binding_value(
+            node_id=1, endpoint_id=1, binding_value=binding_value
+        )
 
         assert len(result) == 1
         assert result[0].cluster_id is None
@@ -55,7 +56,9 @@ class TestParseBindingValueNoneCluster:
                 "Cluster": 0,  # 0 is falsy but valid
             }
         ]
-        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+        result = _parse_binding_value(
+            node_id=1, endpoint_id=1, binding_value=binding_value
+        )
 
         assert len(result) == 1
         # Note: 0 is a valid cluster ID, should not be converted to None
@@ -72,7 +75,9 @@ class TestParseBindingValueNoneCluster:
                 "Cluster": 6,  # On/Off cluster
             }
         ]
-        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+        result = _parse_binding_value(
+            node_id=1, endpoint_id=1, binding_value=binding_value
+        )
 
         assert len(result) == 1
         assert result[0].cluster_id == 6
@@ -93,7 +98,9 @@ class TestParseBindingValueNoneCluster:
             group = None
 
         binding_value = [MockBinding()]
-        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+        result = _parse_binding_value(
+            node_id=1, endpoint_id=1, binding_value=binding_value
+        )
 
         assert len(result) == 1
         assert result[0].cluster_id is None
@@ -110,7 +117,9 @@ class TestParseBindingValueNoneCluster:
             group = None
 
         binding_value = [MockBinding()]
-        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+        result = _parse_binding_value(
+            node_id=1, endpoint_id=1, binding_value=binding_value
+        )
 
         assert len(result) == 1
         assert result[0].cluster_id == 8
@@ -122,7 +131,9 @@ class TestParseBindingValueNoneCluster:
             {"Node": 6, "Endpoint": 1, "Cluster": None},
             {"Node": 7, "Endpoint": 2},  # No Cluster key
         ]
-        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+        result = _parse_binding_value(
+            node_id=1, endpoint_id=1, binding_value=binding_value
+        )
 
         assert len(result) == 3
         assert result[0].cluster_id == 6
@@ -137,7 +148,9 @@ class TestParseBindingValueNoneCluster:
                 "Cluster": None,
             }
         ]
-        result = _parse_binding_value(node_id=1, endpoint_id=1, binding_value=binding_value)
+        result = _parse_binding_value(
+            node_id=1, endpoint_id=1, binding_value=binding_value
+        )
 
         assert len(result) == 1
         assert result[0].cluster_id is None

--- a/tests/unit/test_demo.py
+++ b/tests/unit/test_demo.py
@@ -1,7 +1,7 @@
 """Unit tests for matter/demo.py."""
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from custom_components.matter_binding_helper.matter.models import (
     ACLEntry,

--- a/tests/unit/test_group_store.py
+++ b/tests/unit/test_group_store.py
@@ -83,6 +83,43 @@ async def test_key_set_ids_are_sequential_and_unique():
 
 
 @pytest.mark.asyncio
+async def test_auto_allocates_group_id_when_none():
+    store = make_store()
+    await store.async_load()
+
+    a = await store.async_create_group(None, "A")
+    b = await store.async_create_group(None, "B")
+
+    assert a.group_id == 1
+    assert b.group_id == 2
+
+
+@pytest.mark.asyncio
+async def test_auto_allocation_skips_existing_ids():
+    store = make_store()
+    await store.async_load()
+    await store.async_create_group(1, "Explicit")  # takes id 1
+
+    auto = await store.async_create_group(None, "Auto")
+    assert auto.group_id == 2  # skipped the taken id 1
+
+
+@pytest.mark.asyncio
+async def test_next_group_id_survives_reload():
+    backing = FakeStore()
+    s1 = GroupStore(MagicMock(), store=backing, key_factory=_counter_keys())
+    await s1.async_load()
+    await s1.async_create_group(None, "A")  # id 1
+
+    s2 = GroupStore(
+        MagicMock(), store=FakeStore(backing.saved), key_factory=_counter_keys()
+    )
+    await s2.async_load()
+    rec = await s2.async_create_group(None, "B")
+    assert rec.group_id == 2
+
+
+@pytest.mark.asyncio
 async def test_create_duplicate_group_raises():
     store = make_store()
     await store.async_load()

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -85,6 +85,17 @@ async def test_real_create_and_list(hass):
 
 
 @pytest.mark.asyncio
+async def test_real_create_auto_allocates_id(hass):
+    """Creating a group without an id auto-allocates and returns it."""
+    result = await create_group(hass, None, "Ambient")
+    assert result.success is True
+    assert result.group_id == 1
+
+    second = await create_group(hass, None, "Kitchen")
+    assert second.group_id == 2
+
+
+@pytest.mark.asyncio
 async def test_real_create_duplicate(hass):
     await create_group(hass, 10, "Hallway")
     dup = await create_group(hass, 10, "Hallway")
@@ -232,6 +243,14 @@ async def test_demo_create_and_list(demo_hass):
 
 
 @pytest.mark.asyncio
+async def test_demo_create_auto_allocates_id(demo_hass):
+    """Demo create without an id allocates the next free id (seed group is 1)."""
+    result = await create_group(demo_hass, None, "Hallway")
+    assert result.success is True
+    assert result.group_id == 2  # seed group occupies id 1
+
+
+@pytest.mark.asyncio
 async def test_demo_create_duplicate_reports_exists(demo_hass):
     result = await create_group(demo_hass, 1, "Dup")
     assert result.success is False
@@ -271,4 +290,5 @@ async def test_result_to_dict_is_serializable(demo_hass):
         "success": True,
         "message": result.message,
         "error_code": None,
+        "group_id": 5,
     }

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,8 +1,5 @@
 """Unit tests for matter/models.py."""
 
-import pytest
-from dataclasses import FrozenInstanceError
-
 from custom_components.matter_binding_helper.matter.models import (
     ACLEntry,
     ACLProvisioningResult,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,5 @@
 """Unit tests for matter/utils.py."""
 
-import pytest
 from unittest.mock import MagicMock
 
 from custom_components.matter_binding_helper.matter.models import (


### PR DESCRIPTION
## Context
Reported UX issue: the Create Group dialog forced the user to enter a **Group ID**. A Matter group ID is an arbitrary 16-bit number (`0x0001`–`0xFFF7`) and a user has no way to know what to pick or which are taken. The store already auto-allocated the *group key set* ID — the *group* ID was just left manual.

## Changes
- **Backend**: `group_store` tracks `next_group_id` (base 1) and allocates the next free id (skipping used ones); `async_create_group(group_id=None)` auto-allocates and survives reload. `create_group` / demo / WS `create_group` take an **optional** `group_id` and return the assigned id (on `GroupOperationResult.group_id`).
- **Frontend**: the Create Group dialog is **name-only by default** — type a name, hit Create; the assigned id shows on the group card. An **"Advanced: set group ID manually" checkbox** reveals a Group ID field (with an explanatory note) for power users who need to match a specific Matter group id (1–65527); the value is validated and passed through. So manual IDs are genuinely available from the UI, not just the API.

## Tests
- Python: store auto-allocation (sequential, skip-existing, survives-reload) + create-without-id (real + demo). **208 unit tests green**, ruff clean.
- Frontend: dialog name-only default, Advanced toggle reveals/validates the id field, emits `{ name }` or `{ name, groupId }`. **332 tests green**, build OK.

> Separate note for the reporter: the "Failed to create group" they hit was the *old* backend's message — their HA was serving the new panel JS but still running pre-0.30.0 Python. A restart/reload loads the new code.