### PR TITLE
chore(dependabot): track Python deps at repo root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
+---
 version: 2
 updates:
+  # Python deps live in the root requirements*.txt files; the custom component's
+  # manifest.json declares no requirements, so target the repo root.
   - package-ecosystem: "pip"
-    directory: "/custom_components/matter_binding_helper"
+    directory: "/"
     schedule:
       interval: "weekly"
 


### PR DESCRIPTION
The `pip` updater targeted `/custom_components/matter_binding_helper`, which has no requirements file (the HA `manifest.json` declares none) — so it found nothing and was effectively a no-op. The actual Python deps live in the root `requirements.txt` / `requirements_dev.txt` / `requirements-test.txt`.

- Point the pip ecosystem at `/` so those get weekly updates.
- Add the YAML `---` document-start marker (pre-existing yamllint warning).