### PR TITLE
ci(hacs): auto-sync hacs.json HA floor via release-please token PR

### DIFF
--- a/.github/workflows/sync-hacs.yml
+++ b/.github/workflows/sync-hacs.yml
@@ -1,0 +1,46 @@
+---
+name: Sync hacs.json
+
+# Keeps hacs.json's minimum Home Assistant version aligned with the
+# `homeassistant` floor in requirements.txt. Runs on PRs that touch either file
+# (including Dependabot's) and commits the fix back to the PR branch — zero-touch.
+on:
+  pull_request:
+    paths:
+      - requirements.txt
+      - hacs.json
+      - scripts/sync_hacs_min_ha.py
+      - .github/workflows/sync-hacs.yml
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    # Only same-repo PRs (Dependabot + maintainers) can push the fix back; fork
+    # PRs get a read-only token, so the final --check flags drift instead.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync hacs.json HA floor from requirements.txt
+        run: python scripts/sync_hacs_min_ha.py
+
+      - name: Commit any update to the PR branch
+        run: |
+          if ! git diff --quiet hacs.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -am "chore: sync hacs.json Home Assistant floor"
+            git push
+          fi
+
+      - name: Verify in sync
+        run: python scripts/sync_hacs_min_ha.py --check

--- a/.github/workflows/sync-hacs.yml
+++ b/.github/workflows/sync-hacs.yml
@@ -2,45 +2,62 @@
 name: Sync hacs.json
 
 # Keeps hacs.json's minimum Home Assistant version aligned with the
-# `homeassistant` floor in requirements.txt. Runs on PRs that touch either file
-# (including Dependabot's) and commits the fix back to the PR branch — zero-touch.
+# `homeassistant` floor in requirements.txt. Runs AFTER a requirements bump lands
+# on main (e.g. a Dependabot security update), then opens a dedicated PR with the
+# hacs.json update and enables auto-merge — using RELEASE_PLEASE_TOKEN so the PR
+# triggers CI (the default GITHUB_TOKEN cannot) and can be auto-merged.
 on:
-  pull_request:
+  push:
+    branches: [main]
     paths:
       - requirements.txt
-      - hacs.json
       - scripts/sync_hacs_min_ha.py
-      - .github/workflows/sync-hacs.yml
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sync:
-    # Only same-repo PRs (Dependabot + maintainers) can push the fix back; fork
-    # PRs get a read-only token, so the final --check flags drift instead.
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Sync hacs.json HA floor from requirements.txt
+      - name: Sync hacs.json from requirements.txt
         run: python scripts/sync_hacs_min_ha.py
 
-      - name: Commit any update to the PR branch
+      - name: Open auto-merge PR if hacs.json changed
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
-          if ! git diff --quiet hacs.json; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git commit -am "chore: sync hacs.json Home Assistant floor"
-            git push
+          if git diff --quiet hacs.json; then
+            echo "hacs.json already in sync; nothing to do."
+            exit 0
           fi
 
-      - name: Verify in sync
-        run: python scripts/sync_hacs_min_ha.py --check
+          # Don't stack duplicate sync PRs.
+          existing=$(gh pr list --state open \
+            --search 'in:title chore: sync hacs.json Home Assistant floor' \
+            --json number --jq '.[].number' | head -1)
+          if [ -n "$existing" ]; then
+            echo "Open hacs.json sync PR #$existing already exists; skipping."
+            exit 0
+          fi
+
+          branch="chore/sync-hacs-floor-${{ github.run_id }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git commit -am "chore: sync hacs.json Home Assistant floor"
+          git push origin "$branch"
+
+          url=$(gh pr create --base main --head "$branch" \
+            --title "chore: sync hacs.json Home Assistant floor" \
+            --body "Auto-generated: aligns hacs.json's \`homeassistant\` minimum with the requirements.txt floor after it changed on main.")
+          gh pr merge "$url" --auto --squash

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Matter Binding Helper",
+  "homeassistant": "2024.1.0",
   "render_readme": true,
   "zip_release": true,
   "filename": "matter_binding_helper.zip"

--- a/scripts/sync_hacs_min_ha.py
+++ b/scripts/sync_hacs_min_ha.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Sync hacs.json's minimum Home Assistant version from requirements.txt.
+
+requirements.txt is the single source of truth: its ``homeassistant>=X`` floor is
+the oldest Home Assistant we support, and HACS gates installs on hacs.json's
+``homeassistant`` key. This keeps the two from drifting (e.g. when Dependabot
+raises the floor for a security advisory).
+
+Usage:
+  sync_hacs_min_ha.py           # write hacs.json to match requirements.txt
+  sync_hacs_min_ha.py --check   # exit 1 if they differ (for CI)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REQUIREMENTS = ROOT / "requirements.txt"
+HACS_JSON = ROOT / "hacs.json"
+
+# homeassistant >= 2024.1.0  /  homeassistant==2024.1.0  (first version wins)
+_FLOOR_RE = re.compile(
+    r"^homeassistant\s*[<>=!~]=?\s*([0-9][0-9A-Za-z.\-]*)", re.IGNORECASE
+)
+
+
+def required_floor() -> str:
+    """Return the Home Assistant version floor declared in requirements.txt."""
+    for raw in REQUIREMENTS.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        match = _FLOOR_RE.match(line)
+        if match:
+            return match.group(1)
+    sys.exit(f"error: no `homeassistant` requirement found in {REQUIREMENTS}")
+
+
+def main() -> int:
+    check = "--check" in sys.argv[1:]
+    floor = required_floor()
+
+    data = json.loads(HACS_JSON.read_text())
+    current = data.get("homeassistant")
+
+    if current == floor:
+        print(f"hacs.json homeassistant is in sync ({floor})")
+        return 0
+
+    if check:
+        print(
+            f"::error file=hacs.json::homeassistant is {current!r} but the "
+            f"requirements.txt floor is {floor!r}. Run scripts/sync_hacs_min_ha.py."
+        )
+        return 1
+
+    data["homeassistant"] = floor
+    HACS_JSON.write_text(json.dumps(data, indent=2) + "\n")
+    print(f"updated hacs.json homeassistant: {current!r} -> {floor!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Context
HACS gates installs on `hacs.json`'s `homeassistant` key — it was unset, so **no minimum HA version was enforced**. This makes `requirements.txt`'s `homeassistant>=X` floor the single source of truth and keeps `hacs.json` aligned automatically.

## Approach (revised)
Rather than committing back to the Dependabot PR branch (which doesn't re-trigger CI with `GITHUB_TOKEN`, has no secret access on Dependabot runs, and can be clobbered on rebase), the workflow runs **after** a `requirements.txt` bump lands on `main` and opens a **dedicated sync PR with `RELEASE_PLEASE_TOKEN`**, then enables auto-merge on it.

Why the release-please token: it's a PAT/App token, so the created PR **triggers CI** (the default `GITHUB_TOKEN` can't) and can be auto-merged. Runs on `push: main` → full secret access, no Dependabot-actor restriction, never touches Dependabot's branch, respects branch protection.

## Changes
- **hacs.json**: seed `"homeassistant": "2024.1.0"` (matches requirements.txt). It's a *floor* (oldest supported), deliberately not the latest tested version.
- **scripts/sync_hacs_min_ha.py**: stdlib-only; writes the HA floor from requirements.txt into hacs.json, or `--check` for manual/pre-commit use. Tested: in-sync passes, drift rewritten, key order preserved.
- **.github/workflows/sync-hacs.yml**: on `push: main` touching `requirements.txt`, sync and open an auto-merge PR via `RELEASE_PLEASE_TOKEN` (dedup-guarded so it won't stack PRs).

## Flow
Dependabot raises the HA floor in `requirements.txt` → that PR merges on its own → this workflow fires on the merge → opens a small hacs.json sync PR → auto-merges. Zero manual steps, no Dependabot-branch coupling.

> ⚠️ By design, keep `homeassistant>=X` as a *range* in requirements.txt; hard-pinning to the latest would lock out users on older HA.