### PR TITLE
feat(groups): manage group members from the UI

### DIFF
--- a/frontend/src/components/dialogs/manage-group-dialog.test.ts
+++ b/frontend/src/components/dialogs/manage-group-dialog.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for ManageGroupDialog component.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { fixture, html } from "@open-wc/testing";
+import {
+  createNode,
+  createEndpoint,
+  captureEvents,
+  elementUpdated,
+  queryShadow,
+  queryShadowAll,
+} from "../../test-utils";
+import type { MatterGroup, MatterNode } from "../../types";
+
+import "./manage-group-dialog";
+import type { ManageGroupDialog } from "./manage-group-dialog";
+
+describe("ManageGroupDialog", () => {
+  let element: ManageGroupDialog;
+
+  const nodes: MatterNode[] = [
+    createNode({
+      nodeId: 3,
+      name: "Ceiling Light",
+      endpoints: [
+        createEndpoint({ id: 0, serverClusters: [] }),
+        createEndpoint({ id: 1, serverClusters: [] }),
+      ],
+    }),
+  ];
+
+  const group: MatterGroup = {
+    group_id: 1,
+    name: "Ambientebeleuchtung",
+    members: [{ node_id: 3, endpoint_id: 1 }],
+  };
+
+  afterEach(() => {
+    element?.remove();
+  });
+
+  it("renders nothing when closed", async () => {
+    element = await fixture(
+      html`<matter-manage-group-dialog .group=${group}></matter-manage-group-dialog>`
+    );
+    expect(queryShadow(element, ".dialog-overlay")).toBeNull();
+  });
+
+  it("lists current members with the resolved device name", async () => {
+    element = await fixture(html`
+      <matter-manage-group-dialog
+        .open=${true}
+        .group=${group}
+        .availableNodes=${nodes}
+      ></matter-manage-group-dialog>
+    `);
+    const text = element.shadowRoot?.textContent ?? "";
+    expect(text).toContain("Ceiling Light");
+    expect(text).toContain("EP 1");
+  });
+
+  it("emits remove-member when Remove is clicked", async () => {
+    element = await fixture(html`
+      <matter-manage-group-dialog
+        .open=${true}
+        .group=${group}
+        .availableNodes=${nodes}
+      ></matter-manage-group-dialog>
+    `);
+    const { events } = captureEvents(element, "remove-member");
+
+    queryShadowAll<HTMLButtonElement>(element, "button")
+      .find((b) => b.textContent?.includes("Remove"))!
+      .click();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].detail).toEqual({ nodeId: 3, endpointId: 1 });
+  });
+
+  it("emits add-member after selecting a node and endpoint", async () => {
+    const emptyGroup: MatterGroup = { group_id: 2, name: "Empty", members: [] };
+    element = await fixture(html`
+      <matter-manage-group-dialog
+        .open=${true}
+        .group=${emptyGroup}
+        .availableNodes=${nodes}
+      ></matter-manage-group-dialog>
+    `);
+    const { events } = captureEvents(element, "add-member");
+
+    const nodeSelect = queryShadow<HTMLSelectElement>(element, "#add-node");
+    nodeSelect!.value = "3";
+    nodeSelect!.dispatchEvent(new Event("change"));
+    await elementUpdated(element);
+
+    const epSelect = queryShadow<HTMLSelectElement>(element, "#add-endpoint");
+    epSelect!.value = "1";
+    epSelect!.dispatchEvent(new Event("change"));
+    await elementUpdated(element);
+
+    queryShadowAll<HTMLButtonElement>(element, "button")
+      .find((b) => b.textContent?.trim() === "Add")!
+      .click();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].detail).toEqual({ nodeId: 3, endpointId: 1 });
+  });
+
+  it("disables Add for an endpoint that is already a member", async () => {
+    // group already has node 3 / ep 1.
+    element = await fixture(html`
+      <matter-manage-group-dialog
+        .open=${true}
+        .group=${group}
+        .availableNodes=${nodes}
+      ></matter-manage-group-dialog>
+    `);
+    const nodeSelect = queryShadow<HTMLSelectElement>(element, "#add-node");
+    nodeSelect!.value = "3";
+    nodeSelect!.dispatchEvent(new Event("change"));
+    await elementUpdated(element);
+
+    const epSelect = queryShadow<HTMLSelectElement>(element, "#add-endpoint");
+    epSelect!.value = "1";
+    epSelect!.dispatchEvent(new Event("change"));
+    await elementUpdated(element);
+
+    const addBtn = queryShadowAll<HTMLButtonElement>(element, "button").find(
+      (b) => b.textContent?.trim() === "Add"
+    );
+    expect(addBtn!.disabled).toBe(true);
+  });
+
+  it("emits close when Close is clicked", async () => {
+    element = await fixture(html`
+      <matter-manage-group-dialog
+        .open=${true}
+        .group=${group}
+        .availableNodes=${nodes}
+      ></matter-manage-group-dialog>
+    `);
+    const { events } = captureEvents(element, "close");
+
+    queryShadowAll<HTMLButtonElement>(element, "button")
+      .find((b) => b.textContent?.includes("Close"))!
+      .click();
+
+    expect(events).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/dialogs/manage-group-dialog.ts
+++ b/frontend/src/components/dialogs/manage-group-dialog.ts
@@ -1,0 +1,289 @@
+/**
+ * ManageGroupDialog component
+ *
+ * Lists a group's members and lets the user add/remove endpoints.
+ */
+
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { buttonStyles, stateStyles } from "../../styles/shared-styles";
+import { dialogBaseStyles } from "../../styles/dialog-styles";
+import type { MatterGroup, MatterNode } from "../../types";
+
+/**
+ * Dialog to manage a Matter group's members.
+ *
+ * @fires add-member - { nodeId: number, endpointId: number }
+ * @fires remove-member - { nodeId: number, endpointId: number }
+ * @fires close - When dismissed
+ */
+@customElement("matter-manage-group-dialog")
+export class ManageGroupDialog extends LitElement {
+  static styles = [
+    buttonStyles,
+    stateStyles,
+    dialogBaseStyles,
+    css`
+      :host {
+        display: contents;
+      }
+      .section-title {
+        font-size: 13px;
+        font-weight: 600;
+        margin: 16px 0 8px;
+        color: var(--primary-text-color);
+      }
+      .member-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--divider-color, #e0e0e0);
+      }
+      .member-label {
+        font-size: 13px;
+        color: var(--primary-text-color);
+      }
+      .empty {
+        font-size: 13px;
+        color: var(--secondary-text-color);
+        padding: 4px 0 8px;
+      }
+      .add-row {
+        display: flex;
+        gap: 8px;
+        align-items: flex-end;
+        flex-wrap: wrap;
+      }
+      .add-field {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        flex: 1;
+        min-width: 120px;
+      }
+      .add-field label {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+      }
+      select {
+        padding: 8px;
+        border: 1px solid var(--divider-color, #e0e0e0);
+        border-radius: 4px;
+        background: var(--card-background-color);
+        color: var(--primary-text-color);
+        font-size: 14px;
+      }
+    `,
+  ];
+
+  /** Whether the dialog is open */
+  @property({ type: Boolean })
+  open = false;
+
+  /** The group being managed */
+  @property({ attribute: false })
+  group: MatterGroup | null = null;
+
+  /** Nodes available to add as members */
+  @property({ attribute: false })
+  availableNodes: MatterNode[] = [];
+
+  /** Whether an action is in progress */
+  @property({ type: Boolean })
+  loading = false;
+
+  @state() private _selectedNodeId: number | null = null;
+  @state() private _selectedEndpointId: number | null = null;
+
+  render() {
+    if (!this.open || !this.group) {
+      return nothing;
+    }
+
+    const group = this.group;
+
+    return html`
+      <div class="dialog-overlay" @click=${this._handleClose}>
+        <div class="dialog" @click=${this._stop}>
+          <div class="dialog-header">
+            ${group.name} <span class="source-info">Group ${group.group_id}</span>
+          </div>
+          <div class="dialog-body">
+            <div class="section-title">Members</div>
+            ${group.members.length === 0
+              ? html`<div class="empty">No members yet. Add one below.</div>`
+              : group.members.map((m) => this._renderMember(m.node_id, m.endpoint_id))}
+
+            <div class="section-title">Add member</div>
+            ${this._renderAddRow()}
+          </div>
+          <div class="dialog-actions">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              @click=${this._handleClose}
+              ?disabled=${this.loading}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderMember(nodeId: number, endpointId: number) {
+    const node = this.availableNodes.find((n) => n.node_id === nodeId);
+    const name = node?.name ?? `Node ${nodeId}`;
+    return html`
+      <div class="member-row">
+        <span class="member-label">${name} — EP ${endpointId}</span>
+        <button
+          type="button"
+          class="btn btn-secondary"
+          @click=${() => this._removeMember(nodeId, endpointId)}
+          ?disabled=${this.loading}
+        >
+          Remove
+        </button>
+      </div>
+    `;
+  }
+
+  private _renderAddRow() {
+    const node = this.availableNodes.find(
+      (n) => n.node_id === this._selectedNodeId
+    );
+    // Endpoints excluding the root (0), which can't be a group member.
+    const endpoints = (node?.endpoints ?? []).filter((e) => e.endpoint_id !== 0);
+
+    return html`
+      <div class="add-row">
+        <div class="add-field">
+          <label for="add-node">Device</label>
+          <select
+            id="add-node"
+            @change=${this._onNodeChange}
+            ?disabled=${this.loading}
+          >
+            <option value="" ?selected=${this._selectedNodeId === null}>
+              Select…
+            </option>
+            ${this.availableNodes.map(
+              (n) => html`
+                <option value=${n.node_id} ?selected=${n.node_id === this._selectedNodeId}>
+                  ${n.name} (${n.node_id})
+                </option>
+              `
+            )}
+          </select>
+        </div>
+        <div class="add-field">
+          <label for="add-endpoint">Endpoint</label>
+          <select
+            id="add-endpoint"
+            @change=${this._onEndpointChange}
+            ?disabled=${this.loading || this._selectedNodeId === null}
+          >
+            <option value="" ?selected=${this._selectedEndpointId === null}>
+              Select…
+            </option>
+            ${endpoints.map(
+              (e) => html`
+                <option
+                  value=${e.endpoint_id}
+                  ?selected=${e.endpoint_id === this._selectedEndpointId}
+                >
+                  EP ${e.endpoint_id}
+                </option>
+              `
+            )}
+          </select>
+        </div>
+        <button
+          type="button"
+          class="btn btn-primary"
+          @click=${this._addMember}
+          ?disabled=${this.loading ||
+          this._selectedNodeId === null ||
+          this._selectedEndpointId === null ||
+          this._isAlreadyMember()}
+        >
+          Add
+        </button>
+      </div>
+    `;
+  }
+
+  private _isAlreadyMember(): boolean {
+    if (
+      !this.group ||
+      this._selectedNodeId === null ||
+      this._selectedEndpointId === null
+    ) {
+      return false;
+    }
+    return this.group.members.some(
+      (m) =>
+        m.node_id === this._selectedNodeId &&
+        m.endpoint_id === this._selectedEndpointId
+    );
+  }
+
+  private _stop(e: Event) {
+    e.stopPropagation();
+  }
+
+  private _onNodeChange(e: Event) {
+    const value = (e.target as HTMLSelectElement).value;
+    this._selectedNodeId = value === "" ? null : parseInt(value, 10);
+    this._selectedEndpointId = null;
+  }
+
+  private _onEndpointChange(e: Event) {
+    const value = (e.target as HTMLSelectElement).value;
+    this._selectedEndpointId = value === "" ? null : parseInt(value, 10);
+  }
+
+  private _addMember() {
+    if (this._selectedNodeId === null || this._selectedEndpointId === null) {
+      return;
+    }
+    this.dispatchEvent(
+      new CustomEvent("add-member", {
+        detail: {
+          nodeId: this._selectedNodeId,
+          endpointId: this._selectedEndpointId,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private _removeMember(nodeId: number, endpointId: number) {
+    this.dispatchEvent(
+      new CustomEvent("remove-member", {
+        detail: { nodeId, endpointId },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private _handleClose() {
+    this._selectedNodeId = null;
+    this._selectedEndpointId = null;
+    this.dispatchEvent(
+      new CustomEvent("close", { bubbles: true, composed: true })
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "matter-manage-group-dialog": ManageGroupDialog;
+  }
+}

--- a/frontend/src/matter-binding-panel.ts
+++ b/frontend/src/matter-binding-panel.ts
@@ -37,6 +37,7 @@ import "./components/bindings/binding-card";
 import "./components/acl/acl-section";
 import "./components/dialogs/create-binding-dialog";
 import "./components/dialogs/create-group-dialog";
+import "./components/dialogs/manage-group-dialog";
 import "./components/dialogs/confirm-dialog";
 import "./components/dialogs/operation-progress-dialog";
 import "./components/dialogs/create-automation-dialog";
@@ -69,6 +70,7 @@ export class MatterBindingPanel extends LitElement {
   @state() private _activeTab: "overview" | "bindings" | "groups" = "overview";
   @state() private _showCreateDialog = false;
   @state() private _showCreateGroupDialog = false;
+  @state() private _manageGroup: MatterGroup | null = null;
   @state() private _allBindings: BindingWithContext[] = [];
   @state() private _recommendations: BindingRecommendation[] = [];
   @state() private _overviewLoading = false;
@@ -727,8 +729,52 @@ export class MatterBindingPanel extends LitElement {
   }
 
   private _handleGroupClick(e: CustomEvent<{ group: MatterGroup }>) {
-    // Placeholder for future group management functionality
-    console.log("Group clicked:", e.detail.group);
+    this._manageGroup = e.detail.group;
+  }
+
+  private _closeManageGroupDialog(): void {
+    this._manageGroup = null;
+  }
+
+  private async _handleAddMember(
+    e: CustomEvent<{ nodeId: number; endpointId: number }>
+  ): Promise<void> {
+    if (!this._manageGroup) return;
+    const groupId = this._manageGroup.group_id;
+    const { nodeId, endpointId } = e.detail;
+    this._actionInProgress = "group-member";
+    try {
+      await api.addToGroup(this.hass, groupId, nodeId, endpointId);
+      await this._refreshManagedGroup(groupId);
+    } catch (err) {
+      this._error = `Failed to add member: ${this._extractErrorMessage(err)}`;
+    } finally {
+      this._actionInProgress = null;
+    }
+  }
+
+  private async _handleRemoveMember(
+    e: CustomEvent<{ nodeId: number; endpointId: number }>
+  ): Promise<void> {
+    if (!this._manageGroup) return;
+    const groupId = this._manageGroup.group_id;
+    const { nodeId, endpointId } = e.detail;
+    this._actionInProgress = "group-member";
+    try {
+      await api.removeFromGroup(this.hass, groupId, nodeId, endpointId);
+      await this._refreshManagedGroup(groupId);
+    } catch (err) {
+      this._error = `Failed to remove member: ${this._extractErrorMessage(err)}`;
+    } finally {
+      this._actionInProgress = null;
+    }
+  }
+
+  /** Reload groups and re-point the open manage dialog at the fresh data. */
+  private async _refreshManagedGroup(groupId: number): Promise<void> {
+    await this._loadGroups();
+    this._manageGroup =
+      this._groups.find((g) => g.group_id === groupId) ?? null;
   }
 
   private _openCreateGroupDialog(): void {
@@ -966,6 +1012,15 @@ export class MatterBindingPanel extends LitElement {
           @create-group=${this._handleCreateGroup}
           @cancel=${this._closeCreateGroupDialog}
         ></matter-create-group-dialog>
+        <matter-manage-group-dialog
+          .open=${this._manageGroup !== null}
+          .group=${this._manageGroup}
+          .availableNodes=${this._nodes}
+          .loading=${this._actionInProgress !== null}
+          @add-member=${this._handleAddMember}
+          @remove-member=${this._handleRemoveMember}
+          @close=${this._closeManageGroupDialog}
+        ></matter-manage-group-dialog>
         <matter-create-binding-dialog
           .open=${this._showCreateDialog}
           .sourceNode=${this._selectedSourceNode}


### PR DESCRIPTION
## Context
Clicking a group in the Groups tab only logged `Group clicked: …` to the console — a placeholder left from the group-management work. This wires it up to actually manage membership.

## Changes
- **manage-group-dialog.ts**: opens on group click. Lists current members (resolved device name + `EP n`) with a per-member **Remove**, and an **Add member** row (device select → endpoint select; Add is disabled until both are chosen and for endpoints already in the group).
- **matter-binding-panel.ts**: `_handleGroupClick` opens the dialog; add/remove call `api.addToGroup` / `api.removeFromGroup`, then reload groups and re-point the open dialog at the fresh data so it updates live.

## Tests
vitest: render + member list, `add-member`/`remove-member` events, already-member Add disabled, close. **338 frontend tests green**, build clean.

Backend (`add_to_group`/`remove_from_group`, demo + real) already exists and is covered — this is frontend-only.