### PR TITLE
test(e2e): real-device groupcast provisioning over host networking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,4 +94,6 @@ jobs:
         run: pip install -r requirements-test.txt
 
       - name: Run integration tests
-        run: python -m pytest tests/ -v --tb=short
+        # tests/e2e needs host networking + real commissioning; it runs in the
+        # dedicated e2e workflow, not here.
+        run: python -m pytest tests/ -v --tb=short --ignore=tests/e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,33 @@
+---
+name: E2E (real devices)
+
+# Commissions the rs-matter virtual devices for real (host networking) and
+# verifies groupcast provisioning end-to-end. Runs on Linux only — host-network
+# Matter commissioning does not work on macOS Docker. Manually triggerable, and
+# on PRs that touch the relevant code.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "custom_components/matter_binding_helper/**"
+      - "devices/rust-device/**"
+      - "tests/e2e/**"
+      - ".github/workflows/e2e.yml"
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: pip install -r requirements-test.txt
+
+      - name: Run e2e tests
+        run: python -m pytest tests/e2e -v --tb=short

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,9 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+        with:
+          # This job only reads the repo and runs tests; it never pushes.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/Makefile
+++ b/Makefile
@@ -69,14 +69,18 @@ format: venv ## Format Python code
 	$(RUFF) format custom_components/matter_binding_helper
 
 test: venv ## Run Python tests
-	$(PYTHON) -m pytest tests/ -v
+	$(PYTHON) -m pytest tests/ -v --ignore=tests/e2e
 
 test-integration: venv ## Run integration tests (uses testcontainers for isolated environment)
 	@echo "Running integration tests with testcontainers..."
 	@echo "Fresh containers will be started automatically."
 	@echo ""
 	$(PIP) install -q -r requirements-test.txt
-	$(PYTHON) -m pytest tests/ -v --tb=short
+	$(PYTHON) -m pytest tests/ -v --tb=short --ignore=tests/e2e
+
+test-e2e: venv ## Run real-device e2e tests (Linux/host-networking only)
+	$(PIP) install -q -r requirements-test.txt
+	$(PYTHON) -m pytest tests/e2e -v --tb=short
 
 # Utility
 shell: ## Open a shell in the HA container

--- a/devices/rust-device/Cargo.toml
+++ b/devices/rust-device/Cargo.toml
@@ -30,8 +30,8 @@ avahi = ["rs-matter/zbus"]
 # ResourceExhausted.
 rs-matter = { git = "https://github.com/project-chip/rs-matter", features = [
     "async-io",
-    "max-group-keys-per-fabric-4",
-    "max-groups-per-fabric-8",
+    "max-group-keys-per-fabric-5",
+    "max-groups-per-fabric-32",
 ] }
 
 # Async runtime

--- a/devices/rust-device/Cargo.toml
+++ b/devices/rust-device/Cargo.toml
@@ -24,14 +24,16 @@ avahi = ["rs-matter/zbus"]
 
 [dependencies]
 # Matter protocol
-# Group capacity features are required for groupcast: without
-# max-group-keys-per-fabric-* the device holds zero application group keys
-# (MAX_GROUP_KEYS_PER_FABRIC defaults to 0) and rejects KeySetWrite with
-# ResourceExhausted.
+# Group capacity features are ALL required for groupcast; each defaults to 0,
+# which makes the device reject group provisioning:
+#   max-group-keys-per-fabric-*       keysets -> KeySetWrite ResourceExhausted
+#   max-groups-per-fabric-*           GroupKeyMap/group table
+#   max-group-endpoints-per-fabric-*  endpoints per group -> AddGroup ResourceExhausted
 rs-matter = { git = "https://github.com/project-chip/rs-matter", features = [
     "async-io",
     "max-group-keys-per-fabric-5",
     "max-groups-per-fabric-32",
+    "max-group-endpoints-per-fabric-5",
 ] }
 
 # Async runtime

--- a/devices/rust-device/Cargo.toml
+++ b/devices/rust-device/Cargo.toml
@@ -24,7 +24,15 @@ avahi = ["rs-matter/zbus"]
 
 [dependencies]
 # Matter protocol
-rs-matter = { git = "https://github.com/project-chip/rs-matter", features = ["async-io"] }
+# Group capacity features are required for groupcast: without
+# max-group-keys-per-fabric-* the device holds zero application group keys
+# (MAX_GROUP_KEYS_PER_FABRIC defaults to 0) and rejects KeySetWrite with
+# ResourceExhausted.
+rs-matter = { git = "https://github.com/project-chip/rs-matter", features = [
+    "async-io",
+    "max-group-keys-per-fabric-4",
+    "max-groups-per-fabric-8",
+] }
 
 # Async runtime
 embassy-futures = "0.1"

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""Real-device (host-networking) e2e tests for groupcast provisioning."""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,267 @@
+"""Fixtures for real-device e2e tests.
+
+Unlike the demo-mode integration tests, these commission the rs-matter virtual
+devices for real. Matter commissioning needs mDNS/IPv6 discovery, which a Docker
+bridge network breaks — so every container runs with ``network_mode=host`` (the
+same setup docker-compose uses successfully). This works on Linux runners
+(GitHub Actions); it does not work on Docker Desktop for Mac, so these tests are
+CI-only.
+
+Flow: start matter-server + both devices + HA on the host network → bootstrap HA
+→ install the Matter integration (pointing at localhost) + our integration
+(real mode, no demo) → parse each device's pairing code from its logs →
+commission both → discover their node ids.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any, Generator
+
+import pytest
+import pytest_asyncio
+import requests
+from testcontainers.core.container import DockerContainer
+from websockets.asyncio.client import connect
+
+from ..conftest import HABootstrapper, HAWebSocketClient
+
+MATTER_SERVER_PORT = 5580
+HA_PORT = 8123
+
+# Cluster ids used to identify commissioned devices.
+CLUSTER_ON_OFF = 6
+CLUSTER_LEVEL_CONTROL = 8
+CLUSTER_BINDING = 30
+CLUSTER_GROUPS = 4
+
+
+def _host_container(image: str, name: str) -> DockerContainer:
+    """A container on the host network (no bridge, no port mapping)."""
+    container = DockerContainer(image).with_name(name)
+    # testcontainers passes kwargs straight to `docker run`.
+    container.with_kwargs(network_mode="host")
+    return container
+
+
+def _build_device_image(project_root: Path, binary: str, tag: str) -> str:
+    import docker
+
+    client = docker.from_env()
+    dockerfile_path = project_root / "devices" / "rust-device"
+    print(f"\n[e2e] Building {binary} image...")
+    client.images.build(
+        path=str(dockerfile_path),
+        tag=tag,
+        buildargs={"BINARY": binary},
+        rm=True,
+    )
+    return tag
+
+
+def _pairing_code_from_logs(container: DockerContainer, timeout: int = 60) -> str:
+    """Extract the device's QR pairing payload (``MT:...``) from its logs."""
+    deadline = time.time() + timeout
+    pattern = re.compile(r"MT:[0-9A-Z.\-/:$%*+ ]{8,}")
+    while time.time() < deadline:
+        stdout, stderr = container.get_logs()
+        text = (stdout or b"").decode("utf-8", "ignore") + (stderr or b"").decode(
+            "utf-8", "ignore"
+        )
+        match = pattern.search(text)
+        if match:
+            return match.group(0).strip()
+        time.sleep(2)
+    raise RuntimeError("Could not find MT: pairing code in device logs")
+
+
+@pytest.fixture(scope="session")
+def project_root() -> Path:
+    return Path(__file__).resolve().parent.parent.parent
+
+
+@pytest.fixture(scope="session")
+def matter_server_container() -> Generator[DockerContainer, None, None]:
+    container = _host_container(
+        "ghcr.io/home-assistant-libs/python-matter-server:stable",
+        "matter-server-e2e",
+    ).with_env("TZ", "UTC")
+    print("\n[e2e] Starting Matter Server (host network)...")
+    container.start()
+
+    deadline = time.time() + 90
+    import socket
+
+    while time.time() < deadline:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(2)
+        ok = sock.connect_ex(("127.0.0.1", MATTER_SERVER_PORT)) == 0
+        sock.close()
+        if ok:
+            break
+        time.sleep(2)
+    else:
+        pytest.fail("Matter Server did not become ready")
+
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="session")
+def dimmable_light_container(
+    project_root: Path,
+) -> Generator[DockerContainer, None, None]:
+    tag = _build_device_image(project_root, "dimmable_light", "matter-dimmable-e2e")
+    container = (
+        _host_container(tag, "matter-dimmable-light-e2e")
+        .with_env("MATTER_DISCRIMINATOR", "3840")
+        .with_env("MATTER_PASSCODE", "20202021")
+        .with_env("MATTER_PORT", "5540")
+        .with_env("RUST_LOG", "info")
+    )
+    print("\n[e2e] Starting dimmable light (host network)...")
+    container.start()
+    time.sleep(5)
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="session")
+def on_off_switch_container(
+    project_root: Path,
+) -> Generator[DockerContainer, None, None]:
+    tag = _build_device_image(project_root, "on_off_switch", "matter-switch-e2e")
+    container = (
+        _host_container(tag, "matter-on-off-switch-e2e")
+        .with_env("MATTER_DISCRIMINATOR", "3841")
+        .with_env("MATTER_PASSCODE", "20202022")
+        .with_env("MATTER_PORT", "5541")
+        .with_env("RUST_LOG", "info")
+    )
+    print("\n[e2e] Starting on/off switch (host network)...")
+    container.start()
+    time.sleep(5)
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="session")
+def ha_container(project_root: Path) -> Generator[DockerContainer, None, None]:
+    component = project_root / "custom_components" / "matter_binding_helper"
+    container = _host_container(
+        "ghcr.io/home-assistant/home-assistant:stable", "ha-e2e"
+    ).with_env("TZ", "UTC")
+    container.with_volume_mapping(
+        str(component),
+        "/config/custom_components/matter_binding_helper",
+        "ro",
+    )
+    print("\n[e2e] Starting Home Assistant (host network)...")
+    container.start()
+
+    url = f"http://127.0.0.1:{HA_PORT}/api/"
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        try:
+            if requests.get(url, timeout=5).status_code in (200, 401):
+                break
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(2)
+    else:
+        pytest.fail("Home Assistant did not become ready")
+
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="session")
+def commissioned(
+    matter_server_container,
+    dimmable_light_container,
+    on_off_switch_container,
+    ha_container,
+) -> dict[str, Any]:
+    """Bootstrap HA, install integrations (real mode), commission both devices."""
+    base_url = f"http://127.0.0.1:{HA_PORT}"
+    boot = HABootstrapper(base_url)
+    if not boot.wait_for_ha(timeout=120):
+        pytest.fail("HA not ready")
+
+    if not boot.needs_onboarding():
+        pytest.fail("HA should need onboarding in a fresh container")
+    access_token = boot.complete_onboarding()
+    assert access_token, "onboarding failed"
+
+    token = boot.create_long_lived_token(access_token)
+    assert token, "token creation failed"
+
+    matter_entry = boot.install_matter_integration(
+        access_token, f"ws://127.0.0.1:{MATTER_SERVER_PORT}/ws"
+    )
+    assert matter_entry, "matter integration install failed"
+    time.sleep(3)
+
+    entry_id = boot.install_integration(access_token)
+    assert entry_id, "matter_binding_helper install failed"
+    # NOTE: real mode — demo mode is deliberately NOT enabled.
+    time.sleep(2)
+
+    light_code = _pairing_code_from_logs(dimmable_light_container)
+    switch_code = _pairing_code_from_logs(on_off_switch_container)
+    print(f"[e2e] light code={light_code}  switch code={switch_code}")
+
+    assert boot.commission_device(access_token, light_code), (
+        "light commissioning failed"
+    )
+    assert boot.commission_device(access_token, switch_code), (
+        "switch commissioning failed"
+    )
+    time.sleep(5)
+
+    return {"host": base_url, "token": token}
+
+
+@pytest_asyncio.fixture
+async def ws_client(commissioned: dict[str, Any]):
+    ws_url = commissioned["host"].replace("http://", "ws://") + "/api/websocket"
+    async with connect(ws_url) as ws:
+        msg = json.loads(await ws.recv())
+        assert msg["type"] == "auth_required"
+        await ws.send(
+            json.dumps({"type": "auth", "access_token": commissioned["token"]})
+        )
+        msg = json.loads(await ws.recv())
+        assert msg["type"] == "auth_ok", f"auth failed: {msg}"
+        yield HAWebSocketClient(ws)
+
+
+async def _list_nodes(ws_client: HAWebSocketClient) -> list[dict[str, Any]]:
+    result = await ws_client.call("matter_binding_helper/list_nodes")
+    return result.get("nodes", [])
+
+
+def _endpoint1_clusters(node: dict[str, Any]) -> set[int]:
+    for ep in node.get("endpoints", []):
+        if ep.get("endpoint_id") == 1:
+            return set(ep.get("server_clusters", []))
+    return set()
+
+
+@pytest_asyncio.fixture
+async def device_nodes(ws_client: HAWebSocketClient) -> dict[str, int]:
+    """Discover the commissioned device node ids by their cluster signatures."""
+    nodes = await _list_nodes(ws_client)
+    light = switch = None
+    for node in nodes:
+        clusters = _endpoint1_clusters(node)
+        if {CLUSTER_ON_OFF, CLUSTER_LEVEL_CONTROL, CLUSTER_GROUPS} <= clusters:
+            light = node["node_id"]
+        elif {CLUSTER_BINDING, CLUSTER_GROUPS} <= clusters:
+            switch = node["node_id"]
+    assert light is not None, f"dimmable light node not found in {nodes}"
+    assert switch is not None, f"on/off switch node not found in {nodes}"
+    return {"light": light, "switch": switch}

--- a/tests/e2e/test_groups_e2e.py
+++ b/tests/e2e/test_groups_e2e.py
@@ -1,0 +1,98 @@
+"""End-to-end groupcast provisioning against real commissioned rs-matter devices.
+
+This is the test the demo-mode harness can't do: it commissions real devices and
+asserts that everything the integration writes for a groupcast binding actually
+lands on the hardware — group key (GroupKeyMap), group-auth ACL, and the binding.
+
+Scope note: it verifies *provisioning*, not physical actuation. A virtual switch
+doesn't autonomously emit a groupcast command (no button), so "the light turned
+on" can't be driven here; but provisioning is exactly what the integration is
+responsible for.
+"""
+
+import json
+
+import pytest
+
+CLUSTER_ON_OFF = 6
+CLUSTER_GROUP_KEY_MANAGEMENT = 63  # 0x003F
+AUTH_MODE_GROUP = 3
+
+
+async def _create_group(ws_client, name: str) -> int:
+    result = await ws_client.call("matter_binding_helper/create_group", name=name)
+    assert result.get("success"), f"create_group failed: {result}"
+    group_id = result.get("group_id")
+    assert isinstance(group_id, int), f"no group_id returned: {result}"
+    return group_id
+
+
+@pytest.mark.asyncio
+async def test_groupcast_binding_provisions_real_devices(ws_client, device_nodes):
+    light = device_nodes["light"]
+    switch = device_nodes["switch"]
+
+    # 1. Create a group and add the light (endpoint 1) as a member.
+    group_id = await _create_group(ws_client, "E2E Lights")
+    add = await ws_client.call(
+        "matter_binding_helper/add_to_group",
+        group_id=group_id,
+        node_id=light,
+        endpoint_id=1,
+    )
+    assert add.get("success"), f"add_to_group failed: {add}"
+
+    # 2. Create a groupcast binding: switch -> group, On/Off.
+    binding = await ws_client.call(
+        "matter_binding_helper/create_binding",
+        source_node_id=switch,
+        source_endpoint_id=1,
+        cluster_id=CLUSTER_ON_OFF,
+        target_group_id=group_id,
+    )
+    assert binding.get("success"), f"groupcast binding failed: {binding}"
+
+    # 3a. The binding is on the switch with a group target.
+    bindings = await ws_client.call(
+        "matter_binding_helper/list_bindings",
+        node_id=switch,
+        endpoint_id=1,
+    )
+    assert any(
+        b.get("target_group_id") == group_id for b in bindings.get("bindings", [])
+    ), f"group binding not on switch: {bindings}"
+
+    # 3b. The group key (GroupKeyMap) was written to source and member: the
+    # group id appears in the Group Key Management cluster dump on both nodes.
+    for node in (light, switch):
+        dump = await ws_client.call(
+            "matter_binding_helper/debug_cluster_attributes",
+            node_id=node,
+            endpoint_id=0,
+            cluster_id=CLUSTER_GROUP_KEY_MANAGEMENT,
+        )
+        assert str(group_id) in json.dumps(dump), (
+            f"group {group_id} not in GroupKeyManagement on node {node}: {dump}"
+        )
+
+    # 3c. The member has a group-auth ACL entry for the group.
+    acl = await ws_client.call("matter_binding_helper/list_acl", node_id=light)
+    entries = acl.get("entries", [])
+    assert any(
+        e.get("auth_mode") == AUTH_MODE_GROUP and group_id in (e.get("subjects") or [])
+        for e in entries
+    ), f"no group-auth ACL for group {group_id} on light: {entries}"
+
+    # 4. Teardown: deleting the binding removes the group-auth ACL.
+    await ws_client.call(
+        "matter_binding_helper/delete_binding",
+        source_node_id=switch,
+        source_endpoint_id=1,
+        cluster_id=CLUSTER_ON_OFF,
+        target_group_id=group_id,
+    )
+    acl_after = await ws_client.call("matter_binding_helper/list_acl", node_id=light)
+    assert not any(
+        e.get("auth_mode") == AUTH_MODE_GROUP and group_id in (e.get("subjects") or [])
+        for e in acl_after.get("entries", [])
+    ), "group-auth ACL should be removed after binding deletion"

--- a/tests/e2e/test_groups_e2e.py
+++ b/tests/e2e/test_groups_e2e.py
@@ -10,13 +10,41 @@ on" can't be driven here; but provisioning is exactly what the integration is
 responsible for.
 """
 
-import json
+from typing import Any
 
 import pytest
 
 CLUSTER_ON_OFF = 6
 CLUSTER_GROUP_KEY_MANAGEMENT = 63  # 0x003F
 AUTH_MODE_GROUP = 3
+
+
+def _group_key_map(dump: dict[str, Any]) -> str:
+    """Return a string view of just the GroupKeyMap attribute (id 0) from a
+    cluster-attributes dump.
+
+    Scoped to the GroupKeyMap so the group-id check can't false-positive on
+    unrelated numeric fields elsewhere in the cluster dump (cluster revision,
+    other attribute ids, etc.).
+    """
+    candidates = []
+    raw = dump.get("raw_attributes_from_node_data") or {}
+    candidates.append(raw.get("0"))
+    candidates.append(raw.get(0))
+    attrs = dump.get("attributes") or {}
+    candidates.append(attrs.get("groupKeyMap"))
+
+    for entry in candidates:
+        if isinstance(entry, dict):
+            # Empty list attributes report length 0 / value "[]".
+            if entry.get("length") == 0:
+                continue
+            value = str(entry.get("value", "")).strip()
+            if value and value != "[]":
+                return value
+        elif isinstance(entry, list) and entry:
+            return str(entry)
+    return ""
 
 
 async def _create_group(ws_client, name: str) -> int:
@@ -63,7 +91,8 @@ async def test_groupcast_binding_provisions_real_devices(ws_client, device_nodes
     ), f"group binding not on switch: {bindings}"
 
     # 3b. The group key (GroupKeyMap) was written to source and member: the
-    # group id appears in the Group Key Management cluster dump on both nodes.
+    # GroupKeyMap attribute (not the whole cluster dump) is non-empty and maps the
+    # group id.
     for node in (light, switch):
         dump = await ws_client.call(
             "matter_binding_helper/debug_cluster_attributes",
@@ -71,8 +100,10 @@ async def test_groupcast_binding_provisions_real_devices(ws_client, device_nodes
             endpoint_id=0,
             cluster_id=CLUSTER_GROUP_KEY_MANAGEMENT,
         )
-        assert str(group_id) in json.dumps(dump), (
-            f"group {group_id} not in GroupKeyManagement on node {node}: {dump}"
+        gkm = _group_key_map(dump)
+        assert gkm, f"GroupKeyMap is empty on node {node}: {dump}"
+        assert str(group_id) in gkm, (
+            f"group {group_id} not mapped in GroupKeyMap on node {node}: {gkm}"
         )
 
     # 3c. The member has a group-auth ACL entry for the group.
@@ -84,13 +115,14 @@ async def test_groupcast_binding_provisions_real_devices(ws_client, device_nodes
     ), f"no group-auth ACL for group {group_id} on light: {entries}"
 
     # 4. Teardown: deleting the binding removes the group-auth ACL.
-    await ws_client.call(
+    deleted = await ws_client.call(
         "matter_binding_helper/delete_binding",
         source_node_id=switch,
         source_endpoint_id=1,
         cluster_id=CLUSTER_ON_OFF,
         target_group_id=group_id,
     )
+    assert deleted.get("success"), f"delete_binding failed: {deleted}"
     acl_after = await ws_client.call("matter_binding_helper/list_acl", node_id=light)
     assert not any(
         e.get("auth_mode") == AUTH_MODE_GROUP and group_id in (e.get("subjects") or [])

--- a/tests/e2e/test_groups_e2e.py
+++ b/tests/e2e/test_groups_e2e.py
@@ -10,6 +10,7 @@ on" can't be driven here; but provisioning is exactly what the integration is
 responsible for.
 """
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -17,6 +18,27 @@ import pytest
 CLUSTER_ON_OFF = 6
 CLUSTER_GROUP_KEY_MANAGEMENT = 63  # 0x003F
 AUTH_MODE_GROUP = 3
+
+
+async def _wait_group_key_map(ws_client, node: int, group_id: int) -> str:
+    """Poll a node's GroupKeyMap until it maps the group (or give up).
+
+    matter-server serves attributes from its subscription cache; a freshly written
+    fabric-scoped GroupKeyMap can lag until the device reports it, so retry.
+    """
+    last = ""
+    for _ in range(12):
+        dump = await ws_client.call(
+            "matter_binding_helper/debug_cluster_attributes",
+            node_id=node,
+            endpoint_id=0,
+            cluster_id=CLUSTER_GROUP_KEY_MANAGEMENT,
+        )
+        last = _group_key_map(dump)
+        if last and str(group_id) in last:
+            return last
+        await asyncio.sleep(3)
+    return last
 
 
 def _group_key_map(dump: dict[str, Any]) -> str:
@@ -94,14 +116,8 @@ async def test_groupcast_binding_provisions_real_devices(ws_client, device_nodes
     # GroupKeyMap attribute (not the whole cluster dump) is non-empty and maps the
     # group id.
     for node in (light, switch):
-        dump = await ws_client.call(
-            "matter_binding_helper/debug_cluster_attributes",
-            node_id=node,
-            endpoint_id=0,
-            cluster_id=CLUSTER_GROUP_KEY_MANAGEMENT,
-        )
-        gkm = _group_key_map(dump)
-        assert gkm, f"GroupKeyMap is empty on node {node}: {dump}"
+        gkm = await _wait_group_key_map(ws_client, node, group_id)
+        assert gkm, f"GroupKeyMap stayed empty on node {node}"
         assert str(group_id) in gkm, (
             f"group {group_id} not mapped in GroupKeyMap on node {node}: {gkm}"
         )


### PR DESCRIPTION
## Context
Closes the e2e gap: the demo-mode integration harness can't prove that groupcast provisioning actually lands on real devices, because Matter commissioning fails on a Docker **bridge** network (mDNS/IPv6). The dev `docker-compose` commissions fine — because it uses **host networking**. This adds a host-networking e2e suite that does the same.

## What it does
- **tests/e2e/conftest.py**: matter-server + dimmable light + on/off switch + HA all on `network_mode=host`; bootstraps HA in **real mode** (no demo), parses each device's `MT:` pairing code from its logs, commissions both, and discovers node ids by cluster signature.
- **tests/e2e/test_groups_e2e.py**: create group → add the light as a member → create a groupcast binding (switch → group, On/Off). Asserts the integration's writes landed **on the hardware**: the binding on the switch, the `GroupKeyMap` on source + member, and the **group-auth ACL** on the member; then deletes the binding and asserts the ACL is gone.
- **.github/workflows/e2e.yml**: dedicated Linux job (host-net commissioning needs Linux); `ci.yml` + `Makefile` exclude `tests/e2e` from the demo-mode run.

## Scope
Verifies **provisioning**, not physical actuation — a virtual switch doesn't autonomously emit a groupcast command (no button), so 'the light turned on' can't be driven; provisioning is exactly what the integration is responsible for.

## Honesty note
Host-network commissioning can't be validated on macOS Docker, so this is **CI-iterated** — the first GitHub Actions runs are the real test. Expect follow-up commits tuning timing / log-parsing / discovery until green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a real-device end-to-end test suite for groupcast binding provisioning (create/delete) with Group Key Management and ACL verification through Home Assistant.
  * Introduced E2E fixtures to build/run device and Home Assistant environments, commission devices, and expose discovered node details to tests.
* **Chores**
  * Updated CI and local test targets to ignore E2E tests in non-E2E runs.
  * Added a dedicated “E2E (real devices)” workflow and a `test-e2e` target for running `tests/e2e`.
* **Dependencies**
  * Enabled required groupcast capacity features for the Rust device build to support group provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->