### PR TITLE
feat(groups): progress UX while a groupcast binding provisions

### DIFF
--- a/frontend/src/group-progress-logic.test.ts
+++ b/frontend/src/group-progress-logic.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import {
+  groupProgressStepStatus,
+  isRelevantGroupProgress,
+} from "./group-progress-logic";
+import type { GroupProgressEvent } from "./types";
+
+describe("groupProgressStepStatus", () => {
+  it("maps provisioning to in_progress", () => {
+    expect(groupProgressStepStatus("provisioning")).toBe("in_progress");
+  });
+  it("maps success to success", () => {
+    expect(groupProgressStepStatus("success")).toBe("success");
+  });
+  it("maps failed to error", () => {
+    expect(groupProgressStepStatus("failed")).toBe("error");
+  });
+});
+
+describe("isRelevantGroupProgress", () => {
+  const event: GroupProgressEvent = {
+    group_id: 5,
+    source_node_id: 4,
+    cluster_id: 6,
+    status: "provisioning",
+    message: "…",
+  };
+
+  it("matches the active source + group", () => {
+    expect(isRelevantGroupProgress(event, 4, 5)).toBe(true);
+  });
+  it("ignores a different source node", () => {
+    expect(isRelevantGroupProgress(event, 9, 5)).toBe(false);
+  });
+  it("ignores a different group", () => {
+    expect(isRelevantGroupProgress(event, 4, 6)).toBe(false);
+  });
+});

--- a/frontend/src/group-progress-logic.ts
+++ b/frontend/src/group-progress-logic.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure helpers for surfacing group provisioning progress (EVENT_GROUP_PROGRESS).
+ */
+
+import type {
+  GroupProgressEvent,
+  GroupProgressStatus,
+  OperationStepStatus,
+} from "./types";
+
+/** Map a group provisioning status to an operation-progress step status. */
+export function groupProgressStepStatus(
+  status: GroupProgressStatus
+): OperationStepStatus {
+  switch (status) {
+    case "failed":
+      return "error";
+    case "success":
+      return "success";
+    default:
+      return "in_progress";
+  }
+}
+
+/** Whether a progress event belongs to the binding being created right now. */
+export function isRelevantGroupProgress(
+  event: GroupProgressEvent,
+  sourceNodeId: number,
+  groupId: number
+): boolean {
+  return event.source_node_id === sourceNodeId && event.group_id === groupId;
+}

--- a/frontend/src/matter-binding-panel.ts
+++ b/frontend/src/matter-binding-panel.ts
@@ -22,11 +22,13 @@ import type {
   OperationProgressState,
   OperationStep,
   ACLProgressEvent,
+  GroupProgressEvent,
 } from "./types";
-import { CLUSTER_NAMES, CLUSTER_ON_OFF, getClusterName, getDeviceTypeName, getClusterBindingDescription, AUTOMATION_TEMPLATES, EVE_CLUSTER_ID, isProprietaryCluster, getClusterInfo, hasThermostatSchedule, EVENT_ACL_PROGRESS } from "./types";
+import { CLUSTER_NAMES, CLUSTER_ON_OFF, getClusterName, getDeviceTypeName, getClusterBindingDescription, AUTOMATION_TEMPLATES, EVE_CLUSTER_ID, isProprietaryCluster, getClusterInfo, hasThermostatSchedule, EVENT_ACL_PROGRESS, EVENT_GROUP_PROGRESS } from "./types";
 import { findMatchingDevice, type DeviceDefinition } from "./device-registry";
 import "./thermostat-schedule-editor";
 import { computeBindingRecommendations } from "./recommendation-logic";
+import { groupProgressStepStatus, isRelevantGroupProgress } from "./group-progress-logic";
 import { filterValidTargetEndpoints, getFirstValidTargetEndpoint, countCompatibleClusters, filterControlClusters } from "./binding-ui-logic";
 import { getRecommendedPrivilege, PRIVILEGE_OPTIONS } from "./acl-logic";
 import * as api from "./api";
@@ -707,21 +709,66 @@ export class MatterBindingPanel extends LitElement {
 
   private async _createGroupBinding(targetGroupId: number, clusterId: number): Promise<void> {
     if (!this._selectedSourceNode || !this._selectedSourceEndpoint) return;
+    const sourceNode = this._selectedSourceNode;
+    const sourceEndpoint = this._selectedSourceEndpoint;
+
+    // Provisioning a groupcast binding writes a group key + ACL to the source
+    // and every member, which takes several seconds — show live progress.
+    this._operationProgress = {
+      title: "Creating groupcast binding",
+      steps: [
+        { label: "Write binding to source", status: "in_progress" },
+        { label: "Provision group key & access on members", status: "pending" },
+      ],
+      currentStepIndex: 0,
+      canCancel: false,
+      completed: false,
+    };
+
     this._actionInProgress = "create-group-binding";
+    let unsubscribe: (() => void) | null = null;
     try {
-      await api.createBinding(
+      unsubscribe = await this.hass.connection.subscribeEvents((event: unknown) => {
+        const data = (event as { data: GroupProgressEvent }).data;
+        if (!isRelevantGroupProgress(data, sourceNode.node_id, targetGroupId)) {
+          return;
+        }
+        this._updateStepStatus(1, groupProgressStepStatus(data.status), data.message);
+      }, EVENT_GROUP_PROGRESS);
+
+      const result = await api.createBinding(
         this.hass,
-        this._selectedSourceNode.node_id,
-        this._selectedSourceEndpoint.endpoint_id,
+        sourceNode.node_id,
+        sourceEndpoint.endpoint_id,
         clusterId,
         undefined,
         undefined,
         targetGroupId
       );
-      await this._loadBindings();
+
+      this._updateStepStatus(0, "success");
+      if (!result.success) {
+        this._operationProgress = this._operationProgress
+          ? { ...this._operationProgress, completed: true, error: result.message }
+          : null;
+      } else {
+        // The provisioning step may not have emitted a terminal event; finalize it.
+        const steps = this._operationProgress?.steps ?? [];
+        if (steps[1] && steps[1].status === "in_progress") {
+          this._updateStepStatus(1, "success");
+        }
+        this._operationProgress = this._operationProgress
+          ? { ...this._operationProgress, completed: true }
+          : null;
+      }
     } catch (err) {
-      this._error = `Failed to create group binding: ${this._extractErrorMessage(err)}`;
+      const message = `Failed to create group binding: ${this._extractErrorMessage(err)}`;
+      this._operationProgress = this._operationProgress
+        ? { ...this._operationProgress, completed: true, error: message }
+        : null;
+      this._error = message;
     } finally {
+      if (unsubscribe) unsubscribe();
       this._actionInProgress = null;
     }
   }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -205,6 +205,16 @@ export interface ACLProgressEvent {
   message: string;
 }
 
+export type GroupProgressStatus = "provisioning" | "success" | "failed";
+
+export interface GroupProgressEvent {
+  group_id: number;
+  source_node_id: number;
+  cluster_id: number;
+  status: GroupProgressStatus;
+  message: string;
+}
+
 // Event name constant
 export const EVENT_ACL_PROGRESS = "matter_binding_helper_acl_progress";
 export const EVENT_GROUP_PROGRESS = "matter_binding_helper_group_progress";


### PR DESCRIPTION
Closes the silent-provisioning gap. Creating a groupcast binding writes a group key + group-auth ACL to the source and every member (several seconds), previously with no feedback. Now surfaced via the existing operation-progress dialog, driven by the backend's `EVENT_GROUP_PROGRESS`.

- `group-progress-logic.ts`: pure status mapping + event-relevance filter (6 unit tests).
- panel: two-step progress dialog, live updates from the event stream, finalize on success/failure. Also fixes a latent `OperationStepStatus` typo (`completed`→`success`) the rollup build doesn't hard-fail on.

Auto-merge to follow.