### PR TITLE
fix(groups): clamp group name to 16 chars for AddGroup (status 135)

### DIFF
--- a/custom_components/matter_binding_helper/matter/groups.py
+++ b/custom_components/matter_binding_helper/matter/groups.py
@@ -52,11 +52,23 @@ def _client_unavailable() -> GroupOperationResult:
     )
 
 
+# Matter limits group names to 16 characters; a longer name makes a device reject
+# AddGroup with CONSTRAINT_ERROR (0x87). The full name is kept in our registry.
+MAX_GROUP_NAME_LEN = 16
+
+
+def device_group_name(name: str) -> str:
+    """Clamp a group name to the Matter 16-char limit for on-device storage."""
+    return name[:MAX_GROUP_NAME_LEN]
+
+
 def _add_group_command(group_id: int, name: str) -> Any:
     """Build the chip Groups.AddGroup command (chip imported lazily)."""
     from chip.clusters import Objects as clusters
 
-    return clusters.Groups.Commands.AddGroup(groupID=group_id, groupName=name)
+    return clusters.Groups.Commands.AddGroup(
+        groupID=group_id, groupName=device_group_name(name)
+    )
 
 
 def _remove_group_command(group_id: int) -> Any:

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -20,10 +20,20 @@ from custom_components.matter_binding_helper.matter.groups import (
     add_to_group,
     create_group,
     delete_group,
+    device_group_name,
     get_groups,
     provision_group_for_binding,
     remove_from_group,
 )
+
+
+def test_device_group_name_clamps_to_16_chars():
+    # Matter rejects AddGroup with names > 16 chars (CONSTRAINT_ERROR).
+    assert device_group_name("Ambientebeleuchtung") == "Ambientebeleucht"
+    assert len(device_group_name("Ambientebeleuchtung")) == 16
+    # Short names pass through unchanged.
+    assert device_group_name("Kitchen") == "Kitchen"
+    assert device_group_name("") == ""
 from custom_components.matter_binding_helper.matter.models import GroupOperationResult
 from custom_components.matter_binding_helper.matter.group_store import (
     _GROUP_STORE_KEY,

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -25,6 +25,11 @@ from custom_components.matter_binding_helper.matter.groups import (
     provision_group_for_binding,
     remove_from_group,
 )
+from custom_components.matter_binding_helper.matter.models import GroupOperationResult
+from custom_components.matter_binding_helper.matter.group_store import (
+    _GROUP_STORE_KEY,
+    GroupStore,
+)
 
 
 def test_device_group_name_clamps_to_16_chars():
@@ -34,11 +39,6 @@ def test_device_group_name_clamps_to_16_chars():
     # Short names pass through unchanged.
     assert device_group_name("Kitchen") == "Kitchen"
     assert device_group_name("") == ""
-from custom_components.matter_binding_helper.matter.models import GroupOperationResult
-from custom_components.matter_binding_helper.matter.group_store import (
-    _GROUP_STORE_KEY,
-    GroupStore,
-)
 
 
 class FakeStore:


### PR DESCRIPTION
## The bug
Adding a member to a group failed on real devices with `Device rejected AddGroup (status 135)` = `CONSTRAINT_ERROR` (0x87). Matter limits group names to **16 characters** (`MAX_GROUP_NAME_LEN`), but we passed the full registry name to `Groups.AddGroup`. A group like **'Ambientebeleuchtung'** (19 chars) could therefore never get members.

## Fix
Clamp the on-device group name to 16 chars (`device_group_name()`); the full name is kept in our registry, so the UI is unaffected.

## How it was found
The new real-device **e2e harness** (#288) + the `matter.sh groupkeys` inspector (#292) on a live fabric: `AddGroup` status decoded to a name-length constraint, not a key-provisioning failure (the GroupKeyMap actually does land — `has_group_material` passes before the name check).

Unit test covers the clamp.