### PR TITLE
feat(groups): Repair Groups affordance

### DIFF
--- a/custom_components/matter_binding_helper/api.py
+++ b/custom_components/matter_binding_helper/api.py
@@ -29,6 +29,7 @@ from .const import (
     WS_TYPE_PROVISION_ACL_FOR_BINDINGS,
     WS_TYPE_REMOVE_ACL,
     WS_TYPE_REMOVE_FROM_GROUP,
+    WS_TYPE_REPAIR_GROUP_BINDINGS,
     WS_TYPE_SET_SCHEDULE,
     WS_TYPE_VERIFY_BINDINGS,
 )
@@ -67,6 +68,7 @@ async def async_setup(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_provision_acl)
     websocket_api.async_register_command(hass, ws_remove_acl)
     websocket_api.async_register_command(hass, ws_provision_acl_for_bindings)
+    websocket_api.async_register_command(hass, ws_repair_group_bindings)
     websocket_api.async_register_command(hass, ws_list_groups)
     websocket_api.async_register_command(hass, ws_create_group)
     websocket_api.async_register_command(hass, ws_delete_group)
@@ -1165,6 +1167,45 @@ async def ws_provision_acl_for_bindings(
     _LOGGER.info("ws_provision_acl_for_bindings called with: %s", msg)
 
     results = await matter_client.provision_acls_for_existing_bindings(
+        hass,
+        node_id=msg["node_id"],
+        endpoint_id=msg["endpoint_id"],
+    )
+
+    connection.send_result(
+        msg["id"],
+        {
+            "success": all(r["success"] for r in results) if results else True,
+            "results": results,
+            "total": len(results),
+            "succeeded": sum(1 for r in results if r["success"]),
+        },
+    )
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): WS_TYPE_REPAIR_GROUP_BINDINGS,
+        vol.Required("node_id"): vol.Coerce(int),
+        vol.Required("endpoint_id"): vol.Coerce(int),
+    }
+)
+@websocket_api.async_response
+async def ws_repair_group_bindings(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Re-provision the group chain for existing groupcast bindings on an endpoint.
+
+    Reads the source endpoint's bindings and re-runs groupcast provisioning
+    (group key on source + members, group-auth ACL on members) for each binding
+    that targets a group. Useful when provisioning failed (e.g. a member was
+    offline) or predates group support.
+    """
+    _LOGGER.info("ws_repair_group_bindings called with: %s", msg)
+
+    results = await matter_client.repair_group_bindings(
         hass,
         node_id=msg["node_id"],
         endpoint_id=msg["endpoint_id"],

--- a/custom_components/matter_binding_helper/const.py
+++ b/custom_components/matter_binding_helper/const.py
@@ -70,6 +70,7 @@ WS_TYPE_LIST_ACL = f"{DOMAIN}/list_acl"
 WS_TYPE_PROVISION_ACL = f"{DOMAIN}/provision_acl"
 WS_TYPE_REMOVE_ACL = f"{DOMAIN}/remove_acl"
 WS_TYPE_PROVISION_ACL_FOR_BINDINGS = f"{DOMAIN}/provision_acl_for_bindings"
+WS_TYPE_REPAIR_GROUP_BINDINGS = f"{DOMAIN}/repair_group_bindings"
 WS_TYPE_CREATE_AUTOMATION = f"{DOMAIN}/create_automation"
 ATTR_ACL = 0  # ACL attribute ID
 

--- a/custom_components/matter_binding_helper/matter/bindings.py
+++ b/custom_components/matter_binding_helper/matter/bindings.py
@@ -1042,3 +1042,53 @@ async def provision_acls_for_existing_bindings(
         )
 
     return results
+
+
+async def repair_group_bindings(
+    hass: HomeAssistant,
+    node_id: int,
+    endpoint_id: int,
+) -> list[dict[str, Any]]:
+    """Re-provision the group chain for existing groupcast bindings on an endpoint.
+
+    The group analogue of provision_acls_for_existing_bindings: reads the source
+    endpoint's bindings and, for each one targeting a group, re-runs the groupcast
+    provisioning (group key on source + members, group-auth ACL on members). Useful
+    when a binding was created while a member was offline, or before provisioning
+    existed.
+
+    Returns a list of per-binding result dicts.
+    """
+    results: list[dict[str, Any]] = []
+    bindings = await get_bindings(hass, node_id, endpoint_id)
+
+    for binding in bindings:
+        # Only groupcast bindings (have a target group and a concrete cluster).
+        if binding.target_group_id is None:
+            continue
+        if binding.cluster_id is None:
+            _LOGGER.debug("repair_group_bindings: skipping wildcard-cluster binding")
+            continue
+
+        _LOGGER.info(
+            "repair_group_bindings: re-provisioning node %s ep %s -> group %s cluster 0x%04X",
+            node_id,
+            endpoint_id,
+            binding.target_group_id,
+            binding.cluster_id,
+        )
+        result = await provision_group_for_binding(
+            hass=hass,
+            source_node_id=node_id,
+            group_id=binding.target_group_id,
+            cluster_id=binding.cluster_id,
+        )
+        results.append(
+            {
+                "target_group_id": binding.target_group_id,
+                "cluster_id": binding.cluster_id,
+                **result.to_dict(),
+            }
+        )
+
+    return results

--- a/custom_components/matter_binding_helper/matter_client.py
+++ b/custom_components/matter_binding_helper/matter_client.py
@@ -82,6 +82,7 @@ from .matter.bindings import (
     delete_binding,
     get_bindings,
     provision_acls_for_existing_bindings,
+    repair_group_bindings,
     verify_bindings,
 )
 
@@ -172,6 +173,7 @@ __all__ = [
     "delete_binding",
     "verify_bindings",
     "provision_acls_for_existing_bindings",
+    "repair_group_bindings",
     # ACL
     "get_acl",
     "write_acl",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -190,6 +190,19 @@ export async function provisionACLForBindings(
   });
 }
 
+/** Re-provision the group chain for a source endpoint's groupcast bindings. */
+export async function repairGroupBindings(
+  hass: HomeAssistant,
+  nodeId: number,
+  endpointId: number
+): Promise<{ success: boolean; total: number; succeeded: number }> {
+  return hass.callWS({
+    type: `${DOMAIN}/repair_group_bindings`,
+    node_id: nodeId,
+    endpoint_id: endpointId,
+  });
+}
+
 export async function listGroups(hass: HomeAssistant): Promise<ListGroupsResponse> {
   return hass.callWS({
     type: `${DOMAIN}/list_groups`,

--- a/frontend/src/components/groups/groups-tab.test.ts
+++ b/frontend/src/components/groups/groups-tab.test.ts
@@ -201,6 +201,18 @@ describe("GroupsTab", () => {
       expect(events).toHaveLength(1);
     });
 
+    it("emits repair-groups-click when the Repair button is clicked", async () => {
+      element = await fixture<GroupsTab>(html`
+        <matter-groups-tab .groups=${[]}></matter-groups-tab>
+      `);
+      const { events } = captureEvents(element, "repair-groups-click");
+
+      const buttons = queryShadowAll<HTMLButtonElement>(element, "button");
+      buttons.find((b) => b.textContent?.trim() === "Repair")!.click();
+
+      expect(events).toHaveLength(1);
+    });
+
     it("emits delete-group (and not group-click) when Delete is clicked", async () => {
       element = await fixture<GroupsTab>(html`
         <matter-groups-tab .groups=${mockGroups}></matter-groups-tab>

--- a/frontend/src/components/groups/groups-tab.ts
+++ b/frontend/src/components/groups/groups-tab.ts
@@ -32,6 +32,11 @@ export class GroupsTab extends LitElement {
         justify-content: space-between;
       }
 
+      .header-actions {
+        display: flex;
+        gap: 8px;
+      }
+
       .group-card-header {
         display: flex;
         align-items: flex-start;
@@ -109,13 +114,23 @@ export class GroupsTab extends LitElement {
       <div class="card">
         <div class="card-header">
           <span>Matter Groups</span>
-          <button
-            type="button"
-            class="btn btn-primary"
-            @click=${this._handleCreateClick}
-          >
-            Create Group
-          </button>
+          <span class="header-actions">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              title="Re-provision keys and access for existing groupcast bindings"
+              @click=${this._handleRepairClick}
+            >
+              Repair
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary"
+              @click=${this._handleCreateClick}
+            >
+              Create Group
+            </button>
+          </span>
         </div>
         ${this.loading
           ? html`<div class="loading">Loading...</div>`
@@ -183,6 +198,13 @@ export class GroupsTab extends LitElement {
 
   private _handleCreateClick() {
     this.dispatchEvent(new CustomEvent("create-group-click", {
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  private _handleRepairClick() {
+    this.dispatchEvent(new CustomEvent("repair-groups-click", {
       bubbles: true,
       composed: true,
     }));

--- a/frontend/src/matter-binding-panel.ts
+++ b/frontend/src/matter-binding-panel.ts
@@ -849,6 +849,44 @@ export class MatterBindingPanel extends LitElement {
     }
   }
 
+  private async _handleRepairGroups(): Promise<void> {
+    // Find the distinct source endpoints that have groupcast bindings.
+    const sources = new Map<string, { nodeId: number; endpointId: number }>();
+    for (const b of this._allBindings) {
+      if (b.binding.target_group_id !== null) {
+        const key = `${b.binding.node_id}/${b.binding.endpoint_id}`;
+        sources.set(key, {
+          nodeId: b.binding.node_id,
+          endpointId: b.binding.endpoint_id,
+        });
+      }
+    }
+    if (sources.size === 0) {
+      this._error = "No groupcast bindings to repair.";
+      return;
+    }
+
+    this._actionInProgress = "repair-groups";
+    try {
+      let total = 0;
+      let succeeded = 0;
+      for (const { nodeId, endpointId } of sources.values()) {
+        const r = await api.repairGroupBindings(this.hass, nodeId, endpointId);
+        total += r.total;
+        succeeded += r.succeeded;
+      }
+      this._error =
+        succeeded === total
+          ? `Repaired ${total} groupcast binding(s).`
+          : `Repaired ${succeeded}/${total} groupcast binding(s); some failed (check device availability).`;
+      await this._loadOverviewData();
+    } catch (err) {
+      this._error = `Failed to repair groups: ${this._extractErrorMessage(err)}`;
+    } finally {
+      this._actionInProgress = null;
+    }
+  }
+
   private _handleDeleteGroup(e: CustomEvent<{ group: MatterGroup }>): void {
     // Deleting a group is destructive (removes its key material and membership);
     // confirm first.
@@ -1062,6 +1100,7 @@ export class MatterBindingPanel extends LitElement {
                   @group-click=${this._handleGroupClick}
                   @create-group-click=${this._openCreateGroupDialog}
                   @delete-group=${this._handleDeleteGroup}
+                  @repair-groups-click=${this._handleRepairGroups}
                 ></matter-groups-tab>
               `}
         <matter-create-group-dialog

--- a/tests/unit/test_repair_groups.py
+++ b/tests/unit/test_repair_groups.py
@@ -1,0 +1,88 @@
+"""Unit tests for repair_group_bindings (re-provision groupcast bindings)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.matter_binding_helper.matter import bindings
+from custom_components.matter_binding_helper.matter.bindings import (
+    repair_group_bindings,
+)
+from custom_components.matter_binding_helper.matter.models import (
+    BindingEntry,
+    GroupOperationResult,
+)
+
+
+@pytest.mark.asyncio
+async def test_repair_only_reprovisions_groupcast_bindings():
+    hass = MagicMock()
+    endpoint_bindings = [
+        # groupcast binding -> should be re-provisioned
+        BindingEntry(node_id=4, endpoint_id=1, cluster_id=6, target_group_id=5),
+        # unicast binding -> ignored
+        BindingEntry(
+            node_id=4,
+            endpoint_id=1,
+            cluster_id=6,
+            target_node_id=2,
+            target_endpoint_id=1,
+        ),
+        # groupcast but wildcard cluster -> ignored (no cluster to provision)
+        BindingEntry(node_id=4, endpoint_id=1, cluster_id=None, target_group_id=7),
+    ]
+
+    provision = AsyncMock(return_value=GroupOperationResult(True, "ok"))
+    with (
+        patch.object(
+            bindings, "get_bindings", AsyncMock(return_value=endpoint_bindings)
+        ),
+        patch.object(bindings, "provision_group_for_binding", provision),
+    ):
+        results = await repair_group_bindings(hass, node_id=4, endpoint_id=1)
+
+    # Only the one valid groupcast binding is re-provisioned.
+    assert provision.await_count == 1
+    call = provision.await_args
+    assert call.kwargs["group_id"] == 5
+    assert call.kwargs["cluster_id"] == 6
+    assert call.kwargs["source_node_id"] == 4
+
+    assert len(results) == 1
+    assert results[0]["target_group_id"] == 5
+    assert results[0]["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_repair_reports_failures():
+    hass = MagicMock()
+    endpoint_bindings = [
+        BindingEntry(node_id=4, endpoint_id=1, cluster_id=6, target_group_id=5),
+    ]
+    provision = AsyncMock(
+        return_value=GroupOperationResult(False, "member offline", "device_error")
+    )
+    with (
+        patch.object(
+            bindings, "get_bindings", AsyncMock(return_value=endpoint_bindings)
+        ),
+        patch.object(bindings, "provision_group_for_binding", provision),
+    ):
+        results = await repair_group_bindings(hass, node_id=4, endpoint_id=1)
+
+    assert results[0]["success"] is False
+    assert "offline" in results[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_repair_no_group_bindings_is_empty():
+    hass = MagicMock()
+    with patch.object(
+        bindings,
+        "get_bindings",
+        AsyncMock(
+            return_value=[BindingEntry(node_id=4, endpoint_id=1, target_node_id=2)]
+        ),
+    ):
+        results = await repair_group_bindings(hass, node_id=4, endpoint_id=1)
+    assert results == []


### PR DESCRIPTION
The group analogue of **Repair ACL**. Re-provisions the groupcast chain (group key on source + members, group-auth ACL on members) for existing group bindings — useful when provisioning failed (e.g. a member was offline) or predates group support.

## Changes
- **bindings.py**: `repair_group_bindings(node, endpoint)` reads the source endpoint's bindings and re-runs `provision_group_for_binding` for each that targets a group (skips unicast + wildcard-cluster). Placed in bindings.py to avoid a groups↔bindings import cycle.
- **api/const/matter_client**: `repair_group_bindings` WS command.
- **frontend**: a **'Repair'** button in the Groups tab header; the panel finds every source endpoint with a groupcast binding and repairs each, then reports totals.

## Tests
Backend: only groupcast re-provisioned, failure reporting, empty case (3). Frontend: repair button emits event. **212 py + 346 fe green**, lint/build clean.

This is the last of the groupcast polish gaps (translations is N/A — the panel UI is hardcoded English and groups aren't in the config flow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Repair" button to the Groups tab interface for managing device bindings
  * Implemented repair functionality for groupcast bindings on Matter devices with per-binding status tracking and aggregate success/failure reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->