### PR TITLE
feat(groups): type-aware group management

### DIFF
--- a/custom_components/matter_binding_helper/api.py
+++ b/custom_components/matter_binding_helper/api.py
@@ -1295,6 +1295,7 @@ async def ws_list_groups(
         vol.Required("type"): WS_TYPE_CREATE_GROUP,
         vol.Optional("group_id"): vol.Coerce(int),
         vol.Required("name"): str,
+        vol.Optional("clusters"): [vol.Coerce(int)],
     }
 )
 @websocket_api.async_response
@@ -1303,8 +1304,13 @@ async def ws_create_group(
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Create a new Matter group. group_id is optional (auto-allocated if absent)."""
-    result = await matter_client.create_group(hass, msg.get("group_id"), msg["name"])
+    """Create a new Matter group. group_id is optional (auto-allocated if absent).
+
+    ``clusters`` records what the group is meant to control (the type authority).
+    """
+    result = await matter_client.create_group(
+        hass, msg.get("group_id"), msg["name"], msg.get("clusters")
+    )
     if result.success:
         connection.send_result(
             msg["id"], {"success": True, "group_id": result.group_id}

--- a/custom_components/matter_binding_helper/matter/demo.py
+++ b/custom_components/matter_binding_helper/matter/demo.py
@@ -333,6 +333,7 @@ def _default_demo_groups() -> dict[int, GroupEntry]:
             group_id=1,
             name="Living Room Lights",
             members=[{"node_id": 1, "endpoint_id": 1}],
+            clusters=[CLUSTER_ON_OFF, CLUSTER_LEVEL_CONTROL],
         ),
     }
 
@@ -346,17 +347,22 @@ def get_demo_groups() -> list[GroupEntry]:
     return [_demo_groups[gid] for gid in sorted(_demo_groups)]
 
 
-def create_demo_group(group_id: int | None, name: str) -> int | None:
+def create_demo_group(
+    group_id: int | None, name: str, clusters: list[int] | None = None
+) -> int | None:
     """Create a demo group.
 
     If ``group_id`` is None, allocate the next free id. Returns the created group
-    id, or None if an explicitly-requested id already exists.
+    id, or None if an explicitly-requested id already exists. ``clusters`` records
+    what the group controls (empty == untyped).
     """
     if group_id is None:
         group_id = (max(_demo_groups) + 1) if _demo_groups else 1
     elif group_id in _demo_groups:
         return None
-    _demo_groups[group_id] = GroupEntry(group_id=group_id, name=name, members=[])
+    _demo_groups[group_id] = GroupEntry(
+        group_id=group_id, name=name, members=[], clusters=list(clusters or [])
+    )
     return group_id
 
 

--- a/custom_components/matter_binding_helper/matter/group_store.py
+++ b/custom_components/matter_binding_helper/matter/group_store.py
@@ -64,6 +64,11 @@ class GroupRecord:
     key_set_id: int
     epoch_key: str  # hex of EPOCH_KEY_BYTES random bytes
     members: list[dict[str, int]] = field(default_factory=list)
+    # The clusters this group is intended to control. Matter groups are untyped
+    # multicast addresses, so this registry is the *only* type authority: it drives
+    # member-endpoint compatibility filtering and groupcast-binding cluster
+    # defaults. Empty means "untyped" (legacy groups created before this field).
+    clusters: list[int] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize for storage."""
@@ -73,6 +78,7 @@ class GroupRecord:
             "key_set_id": self.key_set_id,
             "epoch_key": self.epoch_key,
             "members": self.members,
+            "clusters": self.clusters,
         }
 
     @classmethod
@@ -87,6 +93,7 @@ class GroupRecord:
                 {"node_id": int(m["node_id"]), "endpoint_id": int(m["endpoint_id"])}
                 for m in data.get("members", [])
             ],
+            clusters=[int(c) for c in data.get("clusters", [])],
         )
 
     def has_member(self, node_id: int, endpoint_id: int) -> bool:
@@ -172,11 +179,18 @@ class GroupStore:
         data["next_group_id"] = gid + 1
         return gid
 
-    async def async_create_group(self, group_id: int | None, name: str) -> GroupRecord:
+    async def async_create_group(
+        self,
+        group_id: int | None,
+        name: str,
+        clusters: list[int] | None = None,
+    ) -> GroupRecord:
         """Create a group, allocating a key set id and a fresh epoch key.
 
         If ``group_id`` is None, the next free group id is allocated automatically
         (the common case — users shouldn't have to invent a Matter group id).
+        ``clusters`` records what the group is meant to control (the type authority
+        for member filtering and binding defaults); an empty list means untyped.
         Raises ValueError if an explicitly-requested group already exists.
         """
         data = self._require_loaded()
@@ -195,6 +209,7 @@ class GroupStore:
             key_set_id=key_set_id,
             epoch_key=self._key_factory(),
             members=[],
+            clusters=[int(c) for c in (clusters or [])],
         )
         data["groups"][key] = record.to_dict()
         await self._save()

--- a/custom_components/matter_binding_helper/matter/groups.py
+++ b/custom_components/matter_binding_helper/matter/groups.py
@@ -100,21 +100,31 @@ async def get_groups(hass: HomeAssistant) -> list[GroupEntry]:
     store = get_group_store(hass)
     await store.async_load()
     return [
-        GroupEntry(group_id=r.group_id, name=r.name, members=list(r.members))
+        GroupEntry(
+            group_id=r.group_id,
+            name=r.name,
+            members=list(r.members),
+            clusters=list(r.clusters),
+        )
         for r in store.list_groups()
     ]
 
 
 async def create_group(
-    hass: HomeAssistant, group_id: int | None, name: str
+    hass: HomeAssistant,
+    group_id: int | None,
+    name: str,
+    clusters: list[int] | None = None,
 ) -> GroupOperationResult:
     """Create a new Matter group (allocates a group key set in the registry).
 
     ``group_id`` is optional; when None the next free id is allocated so users
-    don't have to invent a Matter group id.
+    don't have to invent a Matter group id. ``clusters`` records what the group is
+    meant to control — the type authority for member filtering and binding
+    defaults, since Matter groups themselves are untyped.
     """
     if is_demo_mode(hass):
-        assigned = create_demo_group(group_id, name)
+        assigned = create_demo_group(group_id, name, clusters)
         if assigned is None:
             return GroupOperationResult(
                 success=False,
@@ -133,7 +143,7 @@ async def create_group(
             message=f"Group {group_id} already exists",
             error_code=GROUP_ALREADY_EXISTS_CODE,
         )
-    record = await store.async_create_group(group_id, name)
+    record = await store.async_create_group(group_id, name, clusters)
     return GroupOperationResult(
         success=True,
         message=f"Created group {record.group_id}",

--- a/custom_components/matter_binding_helper/matter/models.py
+++ b/custom_components/matter_binding_helper/matter/models.py
@@ -131,6 +131,8 @@ class GroupEntry:
     group_id: int
     name: str
     members: list[dict[str, int]]  # [{"node_id": x, "endpoint_id": y}]
+    # Clusters this group controls (the type authority; empty == untyped).
+    clusters: list[int] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
@@ -138,6 +140,7 @@ class GroupEntry:
             "group_id": self.group_id,
             "name": self.name,
             "members": self.members,
+            "clusters": self.clusters,
         }
 
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -212,12 +212,14 @@ export async function listGroups(hass: HomeAssistant): Promise<ListGroupsRespons
 export async function createGroup(
   hass: HomeAssistant,
   name: string,
-  groupId?: number
+  groupId?: number,
+  clusters?: number[]
 ): Promise<SuccessResponse> {
   return hass.callWS({
     type: `${DOMAIN}/create_group`,
     name,
     ...(groupId !== undefined ? { group_id: groupId } : {}),
+    ...(clusters && clusters.length > 0 ? { clusters } : {}),
   });
 }
 

--- a/frontend/src/components/dialogs/create-binding-dialog.test.ts
+++ b/frontend/src/components/dialogs/create-binding-dialog.test.ts
@@ -413,5 +413,86 @@ describe("CreateBindingDialog", () => {
       // Cluster defaults to the first source client cluster (On/Off).
       expect(events[0].detail.clusterId).toBe(TEST_CLUSTERS.ON_OFF);
     });
+
+    it("defaults the cluster to a typed group's primary cluster", async () => {
+      // Source can emit On/Off and Level; the group is typed primarily as Level.
+      const typedGroups = [
+        {
+          group_id: 7,
+          name: "Brightness",
+          members: [],
+          clusters: [TEST_CLUSTERS.LEVEL_CONTROL, TEST_CLUSTERS.ON_OFF],
+        },
+      ];
+      element = await fixture<CreateBindingDialog>(html`
+        <matter-create-binding-dialog
+          .open=${true}
+          .sourceNode=${sourceNode}
+          .sourceEndpoint=${sourceEndpoint}
+          .availableNodes=${targetNodes}
+          .availableGroups=${typedGroups}
+        ></matter-create-binding-dialog>
+      `);
+
+      const typeSelect = queryShadow<HTMLSelectElement>(element, "#targetType");
+      typeSelect!.value = "group";
+      typeSelect!.dispatchEvent(new Event("change"));
+      await elementUpdated(element);
+
+      const groupSelect = queryShadow<HTMLSelectElement>(element, "#targetGroup");
+      groupSelect!.value = "7";
+      groupSelect!.dispatchEvent(new Event("change"));
+      await elementUpdated(element);
+
+      const { events } = captureEvents<{
+        targetGroupId: number;
+        clusterId: number;
+      }>(element, "create-binding");
+
+      queryShadowAll<HTMLButtonElement>(element, "button")
+        .find((b) => b.textContent?.includes("Create Binding"))!
+        .click();
+
+      expect(events).toHaveLength(1);
+      // Not On/Off (the legacy first-client-cluster default) — the group's type wins.
+      expect(events[0].detail.clusterId).toBe(TEST_CLUSTERS.LEVEL_CONTROL);
+    });
+
+    it("restricts the cluster options to the group's clusters", async () => {
+      const typedGroups = [
+        {
+          group_id: 7,
+          name: "Brightness",
+          members: [],
+          clusters: [TEST_CLUSTERS.LEVEL_CONTROL],
+        },
+      ];
+      element = await fixture<CreateBindingDialog>(html`
+        <matter-create-binding-dialog
+          .open=${true}
+          .sourceNode=${sourceNode}
+          .sourceEndpoint=${sourceEndpoint}
+          .availableNodes=${targetNodes}
+          .availableGroups=${typedGroups}
+        ></matter-create-binding-dialog>
+      `);
+
+      const typeSelect = queryShadow<HTMLSelectElement>(element, "#targetType");
+      typeSelect!.value = "group";
+      typeSelect!.dispatchEvent(new Event("change"));
+      await elementUpdated(element);
+      const groupSelect = queryShadow<HTMLSelectElement>(element, "#targetGroup");
+      groupSelect!.value = "7";
+      groupSelect!.dispatchEvent(new Event("change"));
+      await elementUpdated(element);
+
+      const options = queryShadowAll<HTMLOptionElement>(
+        element,
+        "#groupCluster option"
+      );
+      const values = options.map((o) => o.value);
+      // On/Off (a source client cluster) is filtered out — only Level remains.
+      expect(values).toEqual([String(TEST_CLUSTERS.LEVEL_CONTROL)]);
+    });
   });
 });

--- a/frontend/src/components/dialogs/create-binding-dialog.ts
+++ b/frontend/src/components/dialogs/create-binding-dialog.ts
@@ -11,6 +11,10 @@ import { buttonStyles, stateStyles, formStyles } from "../../styles/shared-style
 import { dialogBaseStyles } from "../../styles/dialog-styles";
 import type { MatterNode, MatterEndpoint, MatterGroup } from "../../types";
 import { getClusterName } from "../../types";
+import {
+  groupControlClusters,
+  groupDefaultCluster,
+} from "../../group-type-logic";
 
 /**
  * A dialog for creating new Matter bindings.
@@ -219,10 +223,44 @@ export class CreateBindingDialog extends LitElement {
     `;
   }
 
-  private _renderGroupTarget() {
+  /**
+   * The clusters offered for a groupcast binding to the selected group.
+   *
+   * A typed group restricts the choice to the clusters it controls that the
+   * source can actually emit (its client clusters); if that intersection is
+   * empty we fall back to the group's clusters so the user can still see what
+   * the group expects. An untyped group (or no selection) just lists the
+   * source's client clusters, as before.
+   */
+  private _groupClusterChoices(): number[] {
     const sourceClientClusters = this.sourceEndpoint?.client_clusters ?? [];
-    if (this._selectedClusterId === null && sourceClientClusters.length > 0) {
-      this._selectedClusterId = sourceClientClusters[0];
+    const group = this.availableGroups.find(
+      (g) => g.group_id === this._selectedGroupId
+    );
+    const groupClusters = group ? groupControlClusters(group) : [];
+    if (groupClusters.length === 0) {
+      return sourceClientClusters;
+    }
+    const intersection = sourceClientClusters.filter((c) =>
+      groupClusters.includes(c)
+    );
+    return intersection.length > 0 ? intersection : groupClusters;
+  }
+
+  private _renderGroupTarget() {
+    const clusterChoices = this._groupClusterChoices();
+    const group = this.availableGroups.find(
+      (g) => g.group_id === this._selectedGroupId
+    );
+    // Default to the group's primary cluster when typed, else the first choice.
+    if (this._selectedClusterId === null && clusterChoices.length > 0) {
+      const preferred = group
+        ? groupDefaultCluster(groupControlClusters(group))
+        : null;
+      this._selectedClusterId =
+        preferred !== null && clusterChoices.includes(preferred)
+          ? preferred
+          : clusterChoices[0];
     }
     return html`
       <div class="form-group">
@@ -236,15 +274,15 @@ export class CreateBindingDialog extends LitElement {
         >
           <option value="" disabled selected>Select a group...</option>
           ${this.availableGroups.map(
-            (group) => html`
-              <option value=${group.group_id}>
-                ${group.name} (ID ${group.group_id})
+            (g) => html`
+              <option value=${g.group_id}>
+                ${g.name} (ID ${g.group_id})
               </option>
             `
           )}
         </select>
       </div>
-      ${sourceClientClusters.length > 0
+      ${clusterChoices.length > 0
         ? html`
             <div class="form-group">
               <label for="groupCluster">Cluster</label>
@@ -255,9 +293,12 @@ export class CreateBindingDialog extends LitElement {
                 @change=${this._handleClusterChange}
                 .value=${this._selectedClusterId?.toString() ?? ""}
               >
-                ${sourceClientClusters.map(
+                ${clusterChoices.map(
                   (clusterId) => html`
-                    <option value=${clusterId}>
+                    <option
+                      value=${clusterId}
+                      ?selected=${clusterId === this._selectedClusterId}
+                    >
                       ${getClusterName(clusterId)}
                     </option>
                   `
@@ -497,8 +538,7 @@ export class CreateBindingDialog extends LitElement {
     e.preventDefault();
 
     if (this._targetType === "group") {
-      const sourceClientClusters = this.sourceEndpoint?.client_clusters ?? [];
-      const clusterId = this._selectedClusterId ?? sourceClientClusters[0];
+      const clusterId = this._selectedClusterId ?? this._groupClusterChoices()[0];
       if (this._selectedGroupId !== null && clusterId !== undefined) {
         this.dispatchEvent(
           new CustomEvent("create-binding", {
@@ -542,6 +582,10 @@ export class CreateBindingDialog extends LitElement {
     const groupId = parseInt((e.target as HTMLSelectElement).value, 10);
     if (!isNaN(groupId)) {
       this._selectedGroupId = groupId;
+      // Clear so the cluster default re-applies for the newly selected group's
+      // type (a Lights group defaults to On/Off, a covers group to Window
+      // Covering, etc.).
+      this._selectedClusterId = null;
     }
   }
 

--- a/frontend/src/components/dialogs/create-group-dialog.test.ts
+++ b/frontend/src/components/dialogs/create-group-dialog.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for CreateGroupDialog component.
+ * Tests for CreateGroupDialog component (two-step type-aware wizard).
  */
 
 import { describe, it, expect, afterEach } from "vitest";
@@ -14,6 +14,45 @@ import {
 import "./create-group-dialog";
 import type { CreateGroupDialog } from "./create-group-dialog";
 
+const CLUSTER_ON_OFF = 0x0006;
+const CLUSTER_LEVEL_CONTROL = 0x0008;
+const CLUSTER_COLOR_CONTROL = 0x0300;
+const CLUSTER_WINDOW_COVERING = 0x0102;
+
+async function openDialog(): Promise<CreateGroupDialog> {
+  return fixture(
+    html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
+  );
+}
+
+function clickButton(element: CreateGroupDialog, text: string) {
+  queryShadowAll<HTMLButtonElement>(element, "button")
+    .find((b) => b.textContent?.trim() === text)!
+    .click();
+}
+
+/** Pick a category card by its visible label. */
+function pickCategory(element: CreateGroupDialog, label: string) {
+  queryShadowAll<HTMLButtonElement>(element, ".category-card")
+    .find((b) => b.textContent?.includes(label))!
+    .click();
+}
+
+/** Advance from step 1 to step 2 by choosing the "Lights" preset. */
+async function gotoNameStep(element: CreateGroupDialog, label = "Lights") {
+  pickCategory(element, label);
+  await elementUpdated(element);
+  clickButton(element, "Next");
+  await elementUpdated(element);
+}
+
+async function setName(element: CreateGroupDialog, name: string) {
+  const nameInput = queryShadow<HTMLInputElement>(element, "#group-name");
+  nameInput!.value = name;
+  nameInput!.dispatchEvent(new Event("input"));
+  await elementUpdated(element);
+}
+
 describe("CreateGroupDialog", () => {
   let element: CreateGroupDialog;
 
@@ -22,138 +61,184 @@ describe("CreateGroupDialog", () => {
   });
 
   it("renders nothing when closed", async () => {
-    element = await fixture(html`<matter-create-group-dialog></matter-create-group-dialog>`);
+    element = await fixture(
+      html`<matter-create-group-dialog></matter-create-group-dialog>`
+    );
     expect(queryShadow(element, ".dialog-overlay")).toBeNull();
   });
 
-  it("renders only a name input when open (id is auto-allocated)", async () => {
-    element = await fixture(
-      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
-    );
-    expect(queryShadow(element, "#group-id")).toBeNull();
-    expect(queryShadow(element, "#group-name")).not.toBeNull();
+  describe("step 1 — choose type", () => {
+    it("shows category presets and Custom, not the name field yet", async () => {
+      element = await openDialog();
+      const cards = queryShadowAll(element, ".category-card");
+      const labels = cards.map((c) => c.textContent);
+      expect(labels.some((l) => l?.includes("Lights"))).toBe(true);
+      expect(labels.some((l) => l?.includes("Custom"))).toBe(true);
+      // Name lives on step 2.
+      expect(queryShadow(element, "#group-name")).toBeNull();
+    });
+
+    it("requires a category before advancing", async () => {
+      element = await openDialog();
+      clickButton(element, "Next");
+      await elementUpdated(element);
+      expect(queryShadow(element, ".error")).not.toBeNull();
+      expect(queryShadow(element, "#group-name")).toBeNull();
+    });
+
+    it("requires a cluster when Custom is chosen", async () => {
+      element = await openDialog();
+      pickCategory(element, "Custom");
+      await elementUpdated(element);
+      clickButton(element, "Next");
+      await elementUpdated(element);
+      expect(queryShadow(element, ".error")).not.toBeNull();
+      expect(queryShadow(element, "#group-name")).toBeNull();
+    });
   });
 
-  it("emits create-group with just the trimmed name", async () => {
-    element = await fixture(
-      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
-    );
-    const { events } = captureEvents(element, "create-group");
+  describe("step 2 — name & create", () => {
+    it("emits create-group with the preset's clusters and trimmed name", async () => {
+      element = await openDialog();
+      const { events } = captureEvents(element, "create-group");
 
-    const nameInput = queryShadow<HTMLInputElement>(element, "#group-name");
-    nameInput!.value = "  Bedroom  ";
-    nameInput!.dispatchEvent(new Event("input"));
-    await elementUpdated(element);
+      await gotoNameStep(element, "Lights");
+      await setName(element, "  Bedroom  ");
+      clickButton(element, "Create");
 
-    const buttons = queryShadowAll<HTMLButtonElement>(element, "button");
-    buttons.find((b) => b.textContent?.includes("Create"))!.click();
+      expect(events).toHaveLength(1);
+      expect(events[0].detail).toEqual({
+        name: "Bedroom",
+        clusters: [CLUSTER_ON_OFF, CLUSTER_LEVEL_CONTROL, CLUSTER_COLOR_CONTROL],
+      });
+    });
 
-    expect(events).toHaveLength(1);
-    expect(events[0].detail).toEqual({ name: "Bedroom" });
+    it("emits a single custom cluster when Custom is chosen", async () => {
+      element = await openDialog();
+      const { events } = captureEvents(element, "create-group");
+
+      pickCategory(element, "Custom");
+      await elementUpdated(element);
+      const select = queryShadow<HTMLSelectElement>(element, "#custom-cluster");
+      select!.value = String(CLUSTER_WINDOW_COVERING);
+      select!.dispatchEvent(new Event("change"));
+      await elementUpdated(element);
+      clickButton(element, "Next");
+      await elementUpdated(element);
+
+      await setName(element, "Blinds");
+      clickButton(element, "Create");
+
+      expect(events).toHaveLength(1);
+      expect(events[0].detail).toEqual({
+        name: "Blinds",
+        clusters: [CLUSTER_WINDOW_COVERING],
+      });
+    });
+
+    it("shows an error and emits nothing for an empty name", async () => {
+      element = await openDialog();
+      const { events } = captureEvents(element, "create-group");
+
+      await gotoNameStep(element);
+      clickButton(element, "Create");
+      await elementUpdated(element);
+
+      expect(events).toHaveLength(0);
+      expect(queryShadow(element, ".error")).not.toBeNull();
+    });
+
+    it("can go Back to change the type", async () => {
+      element = await openDialog();
+      await gotoNameStep(element);
+      expect(queryShadow(element, "#group-name")).not.toBeNull();
+
+      clickButton(element, "Back");
+      await elementUpdated(element);
+      expect(queryShadow(element, ".category-list")).not.toBeNull();
+      expect(queryShadow(element, "#group-name")).toBeNull();
+    });
+
+    it("hides the group-id field until Advanced is checked", async () => {
+      element = await openDialog();
+      await gotoNameStep(element);
+      expect(queryShadow(element, "#group-id")).toBeNull();
+
+      const advanced = queryShadow<HTMLInputElement>(
+        element,
+        ".advanced-toggle input"
+      );
+      advanced!.checked = true;
+      advanced!.dispatchEvent(new Event("change"));
+      await elementUpdated(element);
+
+      expect(queryShadow(element, "#group-id")).not.toBeNull();
+      expect(queryShadow(element, ".note")).not.toBeNull();
+    });
+
+    it("emits the manual id alongside clusters when Advanced is set", async () => {
+      element = await openDialog();
+      const { events } = captureEvents(element, "create-group");
+
+      await gotoNameStep(element, "Outlets");
+      await setName(element, "Bedroom");
+
+      const advanced = queryShadow<HTMLInputElement>(
+        element,
+        ".advanced-toggle input"
+      );
+      advanced!.checked = true;
+      advanced!.dispatchEvent(new Event("change"));
+      await elementUpdated(element);
+
+      const idInput = queryShadow<HTMLInputElement>(element, "#group-id");
+      idInput!.value = "100";
+      idInput!.dispatchEvent(new Event("input"));
+      await elementUpdated(element);
+
+      clickButton(element, "Create");
+
+      expect(events).toHaveLength(1);
+      expect(events[0].detail).toEqual({
+        name: "Bedroom",
+        clusters: [CLUSTER_ON_OFF],
+        groupId: 100,
+      });
+    });
+
+    it("rejects an out-of-range manual id", async () => {
+      element = await openDialog();
+      const { events } = captureEvents(element, "create-group");
+
+      await gotoNameStep(element);
+      await setName(element, "Bedroom");
+
+      const advanced = queryShadow<HTMLInputElement>(
+        element,
+        ".advanced-toggle input"
+      );
+      advanced!.checked = true;
+      advanced!.dispatchEvent(new Event("change"));
+      await elementUpdated(element);
+
+      const idInput = queryShadow<HTMLInputElement>(element, "#group-id");
+      idInput!.value = "99999";
+      idInput!.dispatchEvent(new Event("input"));
+      await elementUpdated(element);
+
+      clickButton(element, "Create");
+      await elementUpdated(element);
+
+      expect(events).toHaveLength(0);
+      expect(queryShadow(element, ".error")).not.toBeNull();
+    });
   });
 
-  it("shows an error and emits nothing for an empty name", async () => {
-    element = await fixture(
-      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
-    );
-    const { events } = captureEvents(element, "create-group");
-
-    const buttons = queryShadowAll<HTMLButtonElement>(element, "button");
-    buttons.find((b) => b.textContent?.includes("Create"))!.click();
-    await elementUpdated(element);
-
-    expect(events).toHaveLength(0);
-    expect(queryShadow(element, ".error")).not.toBeNull();
-  });
-
-  it("hides the group-id field until Advanced is checked", async () => {
-    element = await fixture(
-      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
-    );
-    expect(queryShadow(element, "#group-id")).toBeNull();
-
-    const advanced = queryShadow<HTMLInputElement>(
-      element,
-      ".advanced-toggle input"
-    );
-    advanced!.checked = true;
-    advanced!.dispatchEvent(new Event("change"));
-    await elementUpdated(element);
-
-    expect(queryShadow(element, "#group-id")).not.toBeNull();
-    expect(queryShadow(element, ".note")).not.toBeNull();
-  });
-
-  it("emits the manual id when Advanced is set with a valid id", async () => {
-    element = await fixture(
-      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
-    );
-    const { events } = captureEvents(element, "create-group");
-
-    const nameInput = queryShadow<HTMLInputElement>(element, "#group-name");
-    nameInput!.value = "Bedroom";
-    nameInput!.dispatchEvent(new Event("input"));
-
-    const advanced = queryShadow<HTMLInputElement>(
-      element,
-      ".advanced-toggle input"
-    );
-    advanced!.checked = true;
-    advanced!.dispatchEvent(new Event("change"));
-    await elementUpdated(element);
-
-    const idInput = queryShadow<HTMLInputElement>(element, "#group-id");
-    idInput!.value = "100";
-    idInput!.dispatchEvent(new Event("input"));
-    await elementUpdated(element);
-
-    const buttons = queryShadowAll<HTMLButtonElement>(element, "button");
-    buttons.find((b) => b.textContent?.includes("Create"))!.click();
-
-    expect(events).toHaveLength(1);
-    expect(events[0].detail).toEqual({ name: "Bedroom", groupId: 100 });
-  });
-
-  it("rejects an out-of-range manual id", async () => {
-    element = await fixture(
-      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
-    );
-    const { events } = captureEvents(element, "create-group");
-
-    const nameInput = queryShadow<HTMLInputElement>(element, "#group-name");
-    nameInput!.value = "Bedroom";
-    nameInput!.dispatchEvent(new Event("input"));
-
-    const advanced = queryShadow<HTMLInputElement>(
-      element,
-      ".advanced-toggle input"
-    );
-    advanced!.checked = true;
-    advanced!.dispatchEvent(new Event("change"));
-    await elementUpdated(element);
-
-    const idInput = queryShadow<HTMLInputElement>(element, "#group-id");
-    idInput!.value = "99999";
-    idInput!.dispatchEvent(new Event("input"));
-    await elementUpdated(element);
-
-    queryShadowAll<HTMLButtonElement>(element, "button")
-      .find((b) => b.textContent?.includes("Create"))!
-      .click();
-    await elementUpdated(element);
-
-    expect(events).toHaveLength(0);
-    expect(queryShadow(element, ".error")).not.toBeNull();
-  });
-
-  it("emits cancel when Cancel clicked", async () => {
-    element = await fixture(
-      html`<matter-create-group-dialog .open=${true}></matter-create-group-dialog>`
-    );
+  it("emits cancel when Cancel clicked on step 1", async () => {
+    element = await openDialog();
     const { events } = captureEvents(element, "cancel");
 
-    const buttons = queryShadowAll<HTMLButtonElement>(element, "button");
-    buttons.find((b) => b.textContent?.includes("Cancel"))!.click();
+    clickButton(element, "Cancel");
 
     expect(events).toHaveLength(1);
   });

--- a/frontend/src/components/dialogs/create-group-dialog.ts
+++ b/frontend/src/components/dialogs/create-group-dialog.ts
@@ -1,20 +1,36 @@
 /**
  * CreateGroupDialog component
  *
- * Dialog for creating a new Matter group. Name-only by default (the group id is
- * auto-allocated by the backend); an "Advanced" toggle reveals an optional
- * manual group id field.
+ * Two-step wizard for creating a Matter group:
+ *   Step 1 — "What will this group control?": pick a preset (Lights, Outlets,
+ *            Window coverings) or Custom (a single cluster). This records the
+ *            group's *type*, which the integration's registry is the sole
+ *            authority for (Matter groups are untyped on the wire).
+ *   Step 2 — Name the group. The group id is auto-allocated by the backend; an
+ *            "Advanced" toggle reveals an optional manual group id field.
  */
 
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { buttonStyles, stateStyles } from "../../styles/shared-styles";
 import { dialogBaseStyles } from "../../styles/dialog-styles";
+import {
+  GROUP_CATEGORIES,
+  CUSTOM_CATEGORY_ID,
+  type GroupCategory,
+} from "../../group-type-logic";
+import { CLUSTER_NAMES, getClusterName } from "../../types";
+
+// Clusters offered in the Custom step — controllable application clusters that
+// make sense as a groupcast target. (Group/management clusters are excluded.)
+const CUSTOM_CLUSTER_CHOICES = [0x0006, 0x0008, 0x0300, 0x0102, 0x0201].filter(
+  (c) => c in CLUSTER_NAMES
+);
 
 /**
  * Dialog to create a Matter group.
  *
- * @fires create-group - { name: string, groupId?: number } (groupId only when set via Advanced)
+ * @fires create-group - { name: string, clusters: number[], groupId?: number }
  * @fires cancel - When cancelled
  */
 @customElement("matter-create-group-dialog")
@@ -37,7 +53,8 @@ export class CreateGroupDialog extends LitElement {
         margin-bottom: 4px;
         color: var(--primary-text-color);
       }
-      input {
+      input,
+      select {
         width: 100%;
         box-sizing: border-box;
         padding: 8px;
@@ -69,6 +86,42 @@ export class CreateGroupDialog extends LitElement {
         margin-top: 6px;
         line-height: 1.4;
       }
+      .category-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .category-card {
+        display: block;
+        width: 100%;
+        text-align: left;
+        padding: 12px 14px;
+        border: 1px solid var(--divider-color, #e0e0e0);
+        border-radius: 8px;
+        background: var(--card-background-color);
+        color: var(--primary-text-color);
+        cursor: pointer;
+        transition: border-color 0.15s, background 0.15s;
+      }
+      .category-card:hover {
+        background: var(--secondary-background-color);
+      }
+      .category-card.selected {
+        border-color: var(--primary-color, #03a9f4);
+      }
+      .category-label {
+        font-weight: 500;
+        margin-bottom: 2px;
+      }
+      .category-desc {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+      }
+      .step-summary {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+        margin-bottom: 12px;
+      }
     `,
   ];
 
@@ -80,6 +133,9 @@ export class CreateGroupDialog extends LitElement {
   @property({ type: Boolean })
   loading = false;
 
+  @state() private _step: 1 | 2 = 1;
+  @state() private _categoryId = "";
+  @state() private _customCluster = "";
   @state() private _name = "";
   @state() private _error = "";
   @state() private _advanced = false;
@@ -95,48 +151,7 @@ export class CreateGroupDialog extends LitElement {
         <div class="dialog" @click=${this._stop}>
           <div class="dialog-header">Create Group</div>
           <div class="dialog-body">
-            <div class="field">
-              <label for="group-name">Name</label>
-              <input
-                id="group-name"
-                type="text"
-                .value=${this._name}
-                @input=${this._onName}
-                ?disabled=${this.loading}
-                placeholder="e.g. Living Room Lights"
-              />
-            </div>
-            <label class="advanced-toggle">
-              <input
-                type="checkbox"
-                .checked=${this._advanced}
-                @change=${this._onAdvancedToggle}
-                ?disabled=${this.loading}
-              />
-              Advanced: set group ID manually
-            </label>
-            ${this._advanced
-              ? html`
-                  <div class="field">
-                    <label for="group-id">Group ID</label>
-                    <input
-                      id="group-id"
-                      type="number"
-                      min="1"
-                      max="65527"
-                      .value=${this._groupId}
-                      @input=${this._onGroupId}
-                      ?disabled=${this.loading}
-                      placeholder="e.g. 100"
-                    />
-                    <div class="note">
-                      Leave Advanced off to let Home Assistant pick a free ID
-                      automatically. Only set this if you need to match a specific
-                      Matter group ID (1–65527); it must not already be in use.
-                    </div>
-                  </div>
-                `
-              : nothing}
+            ${this._step === 1 ? this._renderStep1() : this._renderStep2()}
             ${this._error
               ? html`<div class="error">${this._error}</div>`
               : nothing}
@@ -145,27 +160,196 @@ export class CreateGroupDialog extends LitElement {
             <button
               type="button"
               class="btn btn-secondary"
-              @click=${this._handleCancel}
+              @click=${this._step === 1 ? this._handleCancel : this._back}
               ?disabled=${this.loading}
             >
-              Cancel
+              ${this._step === 1 ? "Cancel" : "Back"}
             </button>
-            <button
-              type="button"
-              class="btn btn-primary ${this.loading ? "btn-loading" : ""}"
-              @click=${this._handleCreate}
-              ?disabled=${this.loading}
-            >
-              Create
-            </button>
+            ${this._step === 1
+              ? html`
+                  <button
+                    type="button"
+                    class="btn btn-primary"
+                    @click=${this._next}
+                  >
+                    Next
+                  </button>
+                `
+              : html`
+                  <button
+                    type="button"
+                    class="btn btn-primary ${this.loading ? "btn-loading" : ""}"
+                    @click=${this._handleCreate}
+                    ?disabled=${this.loading}
+                  >
+                    Create
+                  </button>
+                `}
           </div>
         </div>
       </div>
     `;
   }
 
+  private _renderStep1() {
+    return html`
+      <div class="field">
+        <label>What will this group control?</label>
+        <div class="category-list">
+          ${GROUP_CATEGORIES.map(
+            (cat) => html`
+              <button
+                type="button"
+                class="category-card ${this._categoryId === cat.id
+                  ? "selected"
+                  : ""}"
+                @click=${() => this._selectCategory(cat)}
+              >
+                <div class="category-label">${cat.label}</div>
+                <div class="category-desc">${cat.description}</div>
+              </button>
+            `
+          )}
+          <button
+            type="button"
+            class="category-card ${this._categoryId === CUSTOM_CATEGORY_ID
+              ? "selected"
+              : ""}"
+            @click=${this._selectCustom}
+          >
+            <div class="category-label">Custom</div>
+            <div class="category-desc">Pick a single cluster manually</div>
+          </button>
+        </div>
+        ${this._categoryId === CUSTOM_CATEGORY_ID
+          ? html`
+              <div class="field" style="margin-top: 12px;">
+                <label for="custom-cluster">Cluster</label>
+                <select
+                  id="custom-cluster"
+                  .value=${this._customCluster}
+                  @change=${this._onCustomCluster}
+                >
+                  <option value="">Select a cluster…</option>
+                  ${CUSTOM_CLUSTER_CHOICES.map(
+                    (c) => html`
+                      <option
+                        value=${c}
+                        ?selected=${this._customCluster === String(c)}
+                      >
+                        ${getClusterName(c)} (0x${c.toString(16).padStart(4, "0")})
+                      </option>
+                    `
+                  )}
+                </select>
+              </div>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private _renderStep2() {
+    const clusters = this._selectedClusters();
+    const typeLabel =
+      this._categoryId === CUSTOM_CATEGORY_ID
+        ? getClusterName(clusters[0])
+        : GROUP_CATEGORIES.find((c) => c.id === this._categoryId)?.label ?? "";
+    return html`
+      <div class="step-summary">Type: ${typeLabel}</div>
+      <div class="field">
+        <label for="group-name">Name</label>
+        <input
+          id="group-name"
+          type="text"
+          .value=${this._name}
+          @input=${this._onName}
+          ?disabled=${this.loading}
+          placeholder="e.g. Living Room Lights"
+        />
+      </div>
+      <label class="advanced-toggle">
+        <input
+          type="checkbox"
+          .checked=${this._advanced}
+          @change=${this._onAdvancedToggle}
+          ?disabled=${this.loading}
+        />
+        Advanced: set group ID manually
+      </label>
+      ${this._advanced
+        ? html`
+            <div class="field">
+              <label for="group-id">Group ID</label>
+              <input
+                id="group-id"
+                type="number"
+                min="1"
+                max="65527"
+                .value=${this._groupId}
+                @input=${this._onGroupId}
+                ?disabled=${this.loading}
+                placeholder="e.g. 100"
+              />
+              <div class="note">
+                Leave Advanced off to let Home Assistant pick a free ID
+                automatically. Only set this if you need to match a specific
+                Matter group ID (1–65527); it must not already be in use.
+              </div>
+            </div>
+          `
+        : nothing}
+    `;
+  }
+
+  /** The clusters implied by the current step-1 selection. */
+  private _selectedClusters(): number[] {
+    if (this._categoryId === CUSTOM_CATEGORY_ID) {
+      const c = parseInt(this._customCluster, 10);
+      return Number.isInteger(c) ? [c] : [];
+    }
+    const preset = GROUP_CATEGORIES.find((c) => c.id === this._categoryId);
+    return preset ? [...preset.clusters] : [];
+  }
+
   private _stop(e: Event) {
     e.stopPropagation();
+  }
+
+  private _selectCategory(cat: GroupCategory) {
+    this._categoryId = cat.id;
+    this._error = "";
+  }
+
+  private _selectCustom() {
+    this._categoryId = CUSTOM_CATEGORY_ID;
+    this._error = "";
+  }
+
+  private _onCustomCluster(e: Event) {
+    this._customCluster = (e.target as HTMLSelectElement).value;
+    this._error = "";
+  }
+
+  private _next() {
+    if (!this._categoryId) {
+      this._error = "Pick what this group will control.";
+      return;
+    }
+    if (
+      this._categoryId === CUSTOM_CATEGORY_ID &&
+      this._selectedClusters().length === 0
+    ) {
+      this._error = "Select a cluster for the custom group.";
+      return;
+    }
+    this._error = "";
+    this._step = 2;
+  }
+
+  private _back() {
+    this._error = "";
+    this._step = 1;
   }
 
   private _onName(e: Event) {
@@ -189,8 +373,10 @@ export class CreateGroupDialog extends LitElement {
       return;
     }
 
-    const detail: { name: string; groupId?: number } = {
+    const clusters = this._selectedClusters();
+    const detail: { name: string; clusters: number[]; groupId?: number } = {
       name: this._name.trim(),
+      clusters,
     };
 
     if (this._advanced && this._groupId.trim() !== "") {
@@ -212,13 +398,20 @@ export class CreateGroupDialog extends LitElement {
   }
 
   private _handleCancel() {
+    this._reset();
+    this.dispatchEvent(
+      new CustomEvent("cancel", { bubbles: true, composed: true })
+    );
+  }
+
+  private _reset() {
+    this._step = 1;
+    this._categoryId = "";
+    this._customCluster = "";
     this._name = "";
     this._groupId = "";
     this._advanced = false;
     this._error = "";
-    this.dispatchEvent(
-      new CustomEvent("cancel", { bubbles: true, composed: true })
-    );
   }
 }
 

--- a/frontend/src/components/dialogs/manage-group-dialog.test.ts
+++ b/frontend/src/components/dialogs/manage-group-dialog.test.ts
@@ -156,6 +156,84 @@ describe("ManageGroupDialog", () => {
     expect(addBtn!.disabled).toBe(true);
   });
 
+  describe("type-aware member filtering", () => {
+    // A node with a light endpoint (On/Off + Level) and a cover endpoint.
+    const mixedNode: MatterNode = createNode({
+      nodeId: 5,
+      name: "Mixed Device",
+      endpoints: [
+        createEndpoint({ id: 0, serverClusters: [] }),
+        createEndpoint({ id: 1, serverClusters: [0x0006, 0x0008] }),
+        createEndpoint({ id: 2, serverClusters: [0x0102] }),
+      ],
+    });
+    const lightsGroup: MatterGroup = {
+      group_id: 9,
+      name: "Lights",
+      members: [],
+      clusters: [0x0006, 0x0008, 0x0300],
+    };
+
+    it("offers only endpoints compatible with the group's clusters", async () => {
+      element = await fixture(html`
+        <matter-manage-group-dialog
+          .open=${true}
+          .group=${lightsGroup}
+          .availableNodes=${[mixedNode]}
+        ></matter-manage-group-dialog>
+      `);
+      const nodeSelect = queryShadow<HTMLSelectElement>(element, "#add-node");
+      nodeSelect!.value = "5";
+      nodeSelect!.dispatchEvent(new Event("change"));
+      await elementUpdated(element);
+
+      // The light endpoint (1) is offered; the cover endpoint (2) is hidden.
+      expect(
+        queryShadow(element, '#add-endpoint option[value="1"]')
+      ).not.toBeNull();
+      expect(
+        queryShadow(element, '#add-endpoint option[value="2"]')
+      ).toBeNull();
+      // And the user is told why something is missing.
+      expect(element.shadowRoot?.textContent).toContain("hidden");
+    });
+
+    it("offers every endpoint for an untyped (legacy) group", async () => {
+      const untyped: MatterGroup = { group_id: 8, name: "Legacy", members: [] };
+      element = await fixture(html`
+        <matter-manage-group-dialog
+          .open=${true}
+          .group=${untyped}
+          .availableNodes=${[mixedNode]}
+        ></matter-manage-group-dialog>
+      `);
+      const nodeSelect = queryShadow<HTMLSelectElement>(element, "#add-node");
+      nodeSelect!.value = "5";
+      nodeSelect!.dispatchEvent(new Event("change"));
+      await elementUpdated(element);
+
+      expect(
+        queryShadow(element, '#add-endpoint option[value="1"]')
+      ).not.toBeNull();
+      expect(
+        queryShadow(element, '#add-endpoint option[value="2"]')
+      ).not.toBeNull();
+    });
+
+    it("shows the group's type in the header", async () => {
+      element = await fixture(html`
+        <matter-manage-group-dialog
+          .open=${true}
+          .group=${lightsGroup}
+          .availableNodes=${[mixedNode]}
+        ></matter-manage-group-dialog>
+      `);
+      expect(queryShadow(element, ".dialog-header")?.textContent).toContain(
+        "Lights"
+      );
+    });
+  });
+
   it("emits close when Close is clicked", async () => {
     element = await fixture(html`
       <matter-manage-group-dialog

--- a/frontend/src/components/dialogs/manage-group-dialog.ts
+++ b/frontend/src/components/dialogs/manage-group-dialog.ts
@@ -10,6 +10,11 @@ import { buttonStyles, stateStyles } from "../../styles/shared-styles";
 import { dialogBaseStyles } from "../../styles/dialog-styles";
 import type { MatterEndpoint, MatterGroup, MatterNode } from "../../types";
 import { getDeviceTypeName } from "../../types";
+import {
+  endpointMatchesGroup,
+  groupControlClusters,
+  groupTypeLabel,
+} from "../../group-type-logic";
 
 /**
  * Dialog to manage a Matter group's members.
@@ -109,7 +114,11 @@ export class ManageGroupDialog extends LitElement {
       <div class="dialog-overlay" @click=${this._handleClose}>
         <div class="dialog" @click=${this._stop}>
           <div class="dialog-header">
-            ${group.name} <span class="source-info">Group ${group.group_id}</span>
+            ${group.name}
+            <span class="source-info">
+              Group ${group.group_id} ·
+              ${groupTypeLabel(groupControlClusters(group))}
+            </span>
           </div>
           <div class="dialog-body">
             <div class="section-title">Members</div>
@@ -169,8 +178,14 @@ export class ManageGroupDialog extends LitElement {
     const node = this.availableNodes.find(
       (n) => n.node_id === this._selectedNodeId
     );
-    // Endpoints excluding the root (0), which can't be a group member.
-    const endpoints = (node?.endpoints ?? []).filter((e) => e.endpoint_id !== 0);
+    // Endpoints excluding the root (0), which can't be a group member, and —
+    // for a typed group — only those that can actually speak one of the group's
+    // clusters. Matter groups are untyped on the wire, so this compatibility
+    // filter is the integration's job, not the device's.
+    const clusters = this.group ? groupControlClusters(this.group) : [];
+    const nonRoot = (node?.endpoints ?? []).filter((e) => e.endpoint_id !== 0);
+    const endpoints = nonRoot.filter((e) => endpointMatchesGroup(e, clusters));
+    const hiddenCount = nonRoot.length - endpoints.length;
 
     return html`
       <div class="add-row">
@@ -227,6 +242,12 @@ export class ManageGroupDialog extends LitElement {
           Add
         </button>
       </div>
+      ${this._selectedNodeId !== null && hiddenCount > 0
+        ? html`<div class="empty">
+            ${hiddenCount} endpoint(s) hidden — they don't support this group's
+            clusters (${groupTypeLabel(clusters)}).
+          </div>`
+        : nothing}
     `;
   }
 

--- a/frontend/src/group-type-logic.test.ts
+++ b/frontend/src/group-type-logic.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for group-type-logic — the pure helpers that turn a group's recorded
+ * cluster set (the integration's type authority) into UI behaviour.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  GROUP_CATEGORIES,
+  CUSTOM_CATEGORY_ID,
+  groupControlClusters,
+  endpointMatchesGroup,
+  groupTypeLabel,
+  groupDefaultCluster,
+} from "./group-type-logic";
+
+const CLUSTER_ON_OFF = 0x0006;
+const CLUSTER_LEVEL_CONTROL = 0x0008;
+const CLUSTER_COLOR_CONTROL = 0x0300;
+const CLUSTER_WINDOW_COVERING = 0x0102;
+
+const ep = (...server_clusters: number[]) => ({ server_clusters });
+
+describe("GROUP_CATEGORIES", () => {
+  it("offers Lights, Outlets and Window coverings presets", () => {
+    expect(GROUP_CATEGORIES.map((c) => c.id)).toEqual([
+      "lights",
+      "outlets",
+      "covers",
+    ]);
+  });
+
+  it("never collides with the custom id", () => {
+    expect(GROUP_CATEGORIES.some((c) => c.id === CUSTOM_CATEGORY_ID)).toBe(false);
+  });
+
+  it("maps the Lights preset to on/off, level and color", () => {
+    const lights = GROUP_CATEGORIES.find((c) => c.id === "lights")!;
+    expect(lights.clusters).toEqual([
+      CLUSTER_ON_OFF,
+      CLUSTER_LEVEL_CONTROL,
+      CLUSTER_COLOR_CONTROL,
+    ]);
+  });
+});
+
+describe("groupControlClusters", () => {
+  it("returns the clusters of a typed group", () => {
+    expect(groupControlClusters({ clusters: [CLUSTER_ON_OFF] })).toEqual([
+      CLUSTER_ON_OFF,
+    ]);
+  });
+
+  it("returns [] for an untyped/legacy group", () => {
+    expect(groupControlClusters({})).toEqual([]);
+    expect(groupControlClusters({ clusters: undefined })).toEqual([]);
+  });
+});
+
+describe("endpointMatchesGroup", () => {
+  it("matches when the endpoint exposes one of the group's clusters", () => {
+    expect(
+      endpointMatchesGroup(ep(CLUSTER_ON_OFF, CLUSTER_LEVEL_CONTROL), [
+        CLUSTER_ON_OFF,
+        CLUSTER_LEVEL_CONTROL,
+        CLUSTER_COLOR_CONTROL,
+      ])
+    ).toBe(true);
+  });
+
+  it("rejects an endpoint that exposes none of the group's clusters", () => {
+    expect(
+      endpointMatchesGroup(ep(CLUSTER_WINDOW_COVERING), [CLUSTER_ON_OFF])
+    ).toBe(false);
+  });
+
+  it("matches everything for an untyped group", () => {
+    expect(endpointMatchesGroup(ep(CLUSTER_WINDOW_COVERING), [])).toBe(true);
+  });
+
+  it("matches an on/off plug against a Lights group (shared On/Off)", () => {
+    // A plug only speaks On/Off, but a Lights group commands On/Off too, so the
+    // plug is a legitimate member for that part of the group.
+    expect(
+      endpointMatchesGroup(ep(CLUSTER_ON_OFF), [
+        CLUSTER_ON_OFF,
+        CLUSTER_LEVEL_CONTROL,
+        CLUSTER_COLOR_CONTROL,
+      ])
+    ).toBe(true);
+  });
+});
+
+describe("groupTypeLabel", () => {
+  it("names a preset cluster set", () => {
+    expect(
+      groupTypeLabel([CLUSTER_ON_OFF, CLUSTER_LEVEL_CONTROL, CLUSTER_COLOR_CONTROL])
+    ).toBe("Lights");
+    expect(groupTypeLabel([CLUSTER_ON_OFF])).toBe("Outlets & switches");
+    expect(groupTypeLabel([CLUSTER_WINDOW_COVERING])).toBe("Window coverings");
+  });
+
+  it("is order-insensitive when matching a preset", () => {
+    expect(
+      groupTypeLabel([CLUSTER_COLOR_CONTROL, CLUSTER_ON_OFF, CLUSTER_LEVEL_CONTROL])
+    ).toBe("Lights");
+  });
+
+  it("falls back to cluster names for a non-preset set", () => {
+    expect(groupTypeLabel([CLUSTER_LEVEL_CONTROL])).toBe("Level Control");
+  });
+
+  it("labels an untyped group as Any type", () => {
+    expect(groupTypeLabel([])).toBe("Any type");
+  });
+});
+
+describe("groupDefaultCluster", () => {
+  it("returns the primary (first) cluster", () => {
+    expect(
+      groupDefaultCluster([CLUSTER_ON_OFF, CLUSTER_LEVEL_CONTROL])
+    ).toBe(CLUSTER_ON_OFF);
+  });
+
+  it("returns null for an untyped group", () => {
+    expect(groupDefaultCluster([])).toBeNull();
+  });
+});

--- a/frontend/src/group-type-logic.ts
+++ b/frontend/src/group-type-logic.ts
@@ -1,0 +1,114 @@
+/**
+ * Group-type logic.
+ *
+ * Matter groups are untyped 16-bit multicast addresses on the wire — the device
+ * has no notion of "this is a lighting group". The integration's registry is the
+ * *only* type authority: each group records the clusters it is meant to control.
+ *
+ * These pure helpers turn that cluster set into the three things the UI needs:
+ *   1. a small set of friendly presets for the create wizard ("what will this
+ *      control?"), plus a Custom escape hatch;
+ *   2. member-endpoint compatibility filtering (only offer endpoints that can
+ *      actually speak one of the group's clusters);
+ *   3. a sensible default cluster for a groupcast binding to the group.
+ *
+ * Kept dependency-free (no Lit) so it is unit-testable in isolation, mirroring
+ * group-progress-logic.ts.
+ */
+
+import {
+  CLUSTER_ON_OFF,
+  CLUSTER_LEVEL_CONTROL,
+  CLUSTER_COLOR_CONTROL,
+  CLUSTER_WINDOW_COVERING,
+  getClusterName,
+} from "./types";
+import type { MatterEndpoint, MatterGroup } from "./types";
+
+/** A preset answer to "what will this group control?". */
+export interface GroupCategory {
+  id: string;
+  label: string;
+  description: string;
+  /** The clusters a member of this group is controlled through. */
+  clusters: number[];
+}
+
+/** The Custom category id — user picks a single cluster instead of a preset. */
+export const CUSTOM_CATEGORY_ID = "custom";
+
+/**
+ * Built-in presets. Ordered most-common-first. "Custom" is intentionally not in
+ * this list; it's handled as an escape hatch by the dialog.
+ */
+export const GROUP_CATEGORIES: GroupCategory[] = [
+  {
+    id: "lights",
+    label: "Lights",
+    description: "On/off, brightness and color control",
+    clusters: [CLUSTER_ON_OFF, CLUSTER_LEVEL_CONTROL, CLUSTER_COLOR_CONTROL],
+  },
+  {
+    id: "outlets",
+    label: "Outlets & switches",
+    description: "On/off control only",
+    clusters: [CLUSTER_ON_OFF],
+  },
+  {
+    id: "covers",
+    label: "Window coverings",
+    description: "Blinds, shades and shutters",
+    clusters: [CLUSTER_WINDOW_COVERING],
+  },
+];
+
+/** The clusters a group controls (empty array for untyped / legacy groups). */
+export function groupControlClusters(
+  group: Pick<MatterGroup, "clusters">
+): number[] {
+  return group.clusters ?? [];
+}
+
+/**
+ * Whether an endpoint can be a member of a group with the given control clusters.
+ *
+ * An endpoint is compatible if it exposes at least one of the group's clusters as
+ * a *server* cluster (i.e. it can be commanded on it). An untyped group (no
+ * clusters) matches every endpoint, preserving legacy behaviour.
+ */
+export function endpointMatchesGroup(
+  endpoint: Pick<MatterEndpoint, "server_clusters">,
+  clusters: number[]
+): boolean {
+  if (clusters.length === 0) {
+    return true;
+  }
+  return clusters.some((c) => endpoint.server_clusters.includes(c));
+}
+
+/**
+ * A friendly label for a group's type: the matching preset name if the cluster
+ * set is exactly a preset, otherwise the cluster names, otherwise "Any type".
+ */
+export function groupTypeLabel(clusters: number[]): string {
+  if (clusters.length === 0) {
+    return "Any type";
+  }
+  const preset = GROUP_CATEGORIES.find(
+    (c) =>
+      c.clusters.length === clusters.length &&
+      c.clusters.every((x) => clusters.includes(x))
+  );
+  if (preset) {
+    return preset.label;
+  }
+  return clusters.map((c) => getClusterName(c)).join(", ");
+}
+
+/**
+ * The cluster a groupcast binding to this group should default to: the group's
+ * primary (first) control cluster, or null if untyped.
+ */
+export function groupDefaultCluster(clusters: number[]): number | null {
+  return clusters.length > 0 ? clusters[0] : null;
+}

--- a/frontend/src/matter-binding-panel.ts
+++ b/frontend/src/matter-binding-panel.ts
@@ -834,12 +834,12 @@ export class MatterBindingPanel extends LitElement {
   }
 
   private async _handleCreateGroup(
-    e: CustomEvent<{ name: string; groupId?: number }>
+    e: CustomEvent<{ name: string; clusters?: number[]; groupId?: number }>
   ): Promise<void> {
-    const { name, groupId } = e.detail;
+    const { name, clusters, groupId } = e.detail;
     this._actionInProgress = "create-group";
     try {
-      await api.createGroup(this.hass, name, groupId);
+      await api.createGroup(this.hass, name, groupId, clusters);
       this._showCreateGroupDialog = false;
       await this._loadGroups();
     } catch (err) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -104,6 +104,13 @@ export interface MatterGroup {
   group_id: number;
   name: string;
   members: GroupMember[];
+  /**
+   * Clusters this group is meant to control. Matter groups are untyped multicast
+   * addresses on the wire, so the integration's registry is the only type
+   * authority — this drives member-endpoint filtering and groupcast-binding
+   * cluster defaults. Empty/undefined means an untyped (legacy) group.
+   */
+  clusters?: number[];
 }
 
 export interface GroupMember {
@@ -285,6 +292,7 @@ export const CLUSTER_ACCESS_CONTROL = 0x001f;
 export const CLUSTER_BASIC_INFO = 0x0028;
 export const CLUSTER_POWER_SOURCE = 0x002f;
 export const CLUSTER_COLOR_CONTROL = 0x0300;
+export const CLUSTER_WINDOW_COVERING = 0x0102;
 export const CLUSTER_THERMOSTAT = 0x0201;
 export const CLUSTER_THERMOSTAT_UI = 0x0204;
 export const CLUSTER_TEMPERATURE_MEASUREMENT = 0x0402;
@@ -317,6 +325,7 @@ export const CLUSTER_NAMES: Record<number, string> = {
   63: "Group Key Management",
   70: "Time Sync",
   [CLUSTER_COLOR_CONTROL]: "Color Control",
+  [CLUSTER_WINDOW_COVERING]: "Window Covering",
   [CLUSTER_THERMOSTAT]: "Thermostat",
   [CLUSTER_THERMOSTAT_UI]: "Thermostat UI",
   514: "Fan Control",

--- a/tests/unit/test_group_store.py
+++ b/tests/unit/test_group_store.py
@@ -203,6 +203,40 @@ async def test_persistence_round_trip_preserves_epoch_key():
 
 
 @pytest.mark.asyncio
+async def test_clusters_default_empty_and_round_trip():
+    """The cluster set (group's type) persists and reloads exactly.
+
+    Matter groups are untyped on the wire, so the store is the only type
+    authority — it must round-trip the cluster list verbatim.
+    """
+    backing = FakeStore()
+    store1 = GroupStore(MagicMock(), store=backing, key_factory=_counter_keys())
+    await store1.async_load()
+
+    untyped = await store1.async_create_group(1, "Legacy")
+    assert untyped.clusters == []
+
+    typed = await store1.async_create_group(2, "Lights", clusters=[0x0006, 0x0008])
+    assert typed.clusters == [0x0006, 0x0008]
+
+    store2 = GroupStore(
+        MagicMock(), store=FakeStore(backing.saved), key_factory=_counter_keys()
+    )
+    await store2.async_load()
+    assert store2.get_group(1).clusters == []
+    assert store2.get_group(2).clusters == [0x0006, 0x0008]
+
+
+@pytest.mark.asyncio
+async def test_clusters_coerced_to_ints():
+    """Cluster ids arriving as strings (JSON) are normalized to ints."""
+    store = make_store()
+    await store.async_load()
+    rec = await store.async_create_group(1, "X", clusters=["6", "8"])
+    assert rec.clusters == [6, 8]
+
+
+@pytest.mark.asyncio
 async def test_next_key_set_id_survives_reload():
     """Key-set-id allocation must not collide after a reload."""
     backing = FakeStore()

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -95,6 +95,23 @@ async def test_real_create_and_list(hass):
 
 
 @pytest.mark.asyncio
+async def test_real_create_with_clusters_round_trips(hass):
+    """The group's controlled-cluster set survives create -> list."""
+    result = await create_group(hass, 10, "Lights", clusters=[0x0006, 0x0008])
+    assert result.success is True
+
+    listed = await get_groups(hass)
+    assert listed[0].clusters == [0x0006, 0x0008]
+
+
+@pytest.mark.asyncio
+async def test_real_create_without_clusters_is_untyped(hass):
+    await create_group(hass, 11, "Untyped")
+    listed = await get_groups(hass)
+    assert listed[0].clusters == []
+
+
+@pytest.mark.asyncio
 async def test_real_create_auto_allocates_id(hass):
     """Creating a group without an id auto-allocates and returns it."""
     result = await create_group(hass, None, "Ambient")
@@ -243,6 +260,16 @@ async def test_demo_lists_seed_group(demo_hass):
     groups_list = await get_groups(demo_hass)
     assert [g.group_id for g in groups_list] == [1]
     assert groups_list[0].name == "Living Room Lights"
+    # The seed group is typed as a lighting group (On/Off + Level Control).
+    assert groups_list[0].clusters == [0x0006, 0x0008]
+
+
+@pytest.mark.asyncio
+async def test_demo_create_with_clusters_round_trips(demo_hass):
+    result = await create_group(demo_hass, 2, "Blinds", clusters=[0x0102])
+    assert result.success is True
+    created = next(g for g in await get_groups(demo_hass) if g.group_id == 2)
+    assert created.clusters == [0x0102]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -296,13 +296,20 @@ class TestGroupEntry:
             group_id=5,
             name="Test Group",
             members=[{"node_id": 3, "endpoint_id": 2}],
+            clusters=[0x0006, 0x0008],
         )
         result = group.to_dict()
         assert result == {
             "group_id": 5,
             "name": "Test Group",
             "members": [{"node_id": 3, "endpoint_id": 2}],
+            "clusters": [0x0006, 0x0008],
         }
+
+    def test_to_dict_defaults_to_untyped(self):
+        """A group created without clusters serializes an empty cluster list."""
+        group = GroupEntry(group_id=5, name="Untyped", members=[])
+        assert group.to_dict()["clusters"] == []
 
 
 class TestACLTarget:


### PR DESCRIPTION
## Why

Matter groups are **untyped** 16-bit multicast addresses on the wire — a device has no notion of "this is a lighting group". So when a user adds a member or creates a groupcast binding, nothing stops them from mixing a window-covering endpoint into a lights group, or binding the wrong cluster. The integration's registry is the **only** place a group's intended type can live.

This makes the registry the type authority and uses it to guide the UI.

## What

**Backend**
- `GroupRecord` / `GroupEntry` gain a `clusters` list — the clusters the group is meant to control (empty = untyped/legacy). Threaded through the group store, demo backend, the `groups` facade, and the `create_group` WS command; persisted and round-tripped verbatim.

**Frontend**
- `group-type-logic.ts` — dependency-free helpers (presets, endpoint compatibility, type label, default cluster), mirroring `group-progress-logic.ts`.
- **Create-group wizard** — step 1 "What will this group control?" (Lights / Outlets / Window coverings presets, plus a **Custom** single-cluster escape hatch) → step 2 name. The Advanced manual group-id override is preserved.
- **Manage-group dialog** — member endpoint picker is filtered to endpoints that actually expose one of the group's clusters; the group's type shows in the header, and hidden endpoints are explained.
- **Groupcast binding dialog** — the cluster defaults to / is restricted to the group's clusters (Lights → On/Off, covers → Window Covering). Untyped groups keep the previous behaviour.

## Tests
- Backend unit: store/groups/models cluster round-trip, demo seed group is typed, JSON int-coercion.
- Frontend vitest: `group-type-logic` (15), wizard two-step flow + custom cluster, member filtering (typed vs untyped), binding cluster default + restriction.
- `npm run build` clean; ruff clean on `custom_components/`.

## Notes
Backwards compatible: groups created before this change have no `clusters` and behave exactly as before (everything matches, no cluster restriction). This is the follow-up captured during the groupcast work — Matter groups being untyped is *why* we ensure cluster types on our end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Group creation is now a two-step wizard: select a group type/category or custom clusters, then set the name.
  * Groups can now be typed by specifying which clusters they control (e.g., Lights, Plugs).
  * Member endpoint filtering now considers cluster compatibility with the selected group type.
  * Binding dialogs now restrict cluster options based on the target group's supported clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->