### PR TITLE
fix(groups): scope GroupKeyMap write to the accessing fabric (matter.js)

### DIFF
--- a/custom_components/matter_binding_helper/const.py
+++ b/custom_components/matter_binding_helper/const.py
@@ -42,6 +42,7 @@ CLUSTER_THERMOSTAT = 0x0201  # Thermostat cluster
 CLUSTER_ACCESS_CONTROL = 0x001F  # Access Control cluster
 CLUSTER_GROUPS = 0x0004  # Groups cluster (per-endpoint group membership)
 CLUSTER_GROUP_KEY_MANAGEMENT = 0x003F  # Group Key Management cluster (root endpoint)
+CLUSTER_OPERATIONAL_CREDENTIALS = 0x003E  # Node Operational Credentials (root endpoint)
 
 # WebSocket commands for thermostat schedules
 WS_TYPE_GET_SCHEDULE = f"{DOMAIN}/get_schedule"
@@ -101,6 +102,11 @@ GROUP_KEY_SECURITY_POLICY_TRUST_FIRST = 0  # GroupKeySecurityPolicyEnum.kTrustFi
 GROUP_ID_BASE = 1
 # GroupKeyManagement attribute IDs
 ATTR_GROUP_KEY_MAP = 0  # GroupKeyMap (list of GroupId -> GroupKeySetID)
+# OperationalCredentials.CurrentFabricIndex — the index of the accessing fabric on
+# the device. Fabric-scoped writes (GroupKeyMap, ACL, Binding) must carry this
+# index; python-matter-server/chip coerces a 0 to it, but matter.js does not, so
+# AddGroup is rejected (UNSUPPORTED_ACCESS) when the mapping lands on fabric 0.
+ATTR_CURRENT_FABRIC_INDEX = 5
 # epochStartTime0 must be non-zero per spec (and rs-matter rejects 0). The exact
 # value only matters for key rotation, which we don't do — a fixed sentinel is fine.
 GROUP_EPOCH_START_TIME = 1

--- a/custom_components/matter_binding_helper/matter/group_keys.py
+++ b/custom_components/matter_binding_helper/matter/group_keys.py
@@ -21,8 +21,10 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 
 from ..const import (
+    ATTR_CURRENT_FABRIC_INDEX,
     ATTR_GROUP_KEY_MAP,
     CLUSTER_GROUP_KEY_MANAGEMENT,
+    CLUSTER_OPERATIONAL_CREDENTIALS,
     GROUP_EPOCH_START_TIME,
     GROUP_KEY_SECURITY_POLICY_TRUST_FIRST,
 )
@@ -33,6 +35,33 @@ from .models import GroupOperationResult
 _LOGGER = logging.getLogger(__name__)
 
 GROUP_KEY_MAP_PATH = f"0/{CLUSTER_GROUP_KEY_MANAGEMENT}/{ATTR_GROUP_KEY_MAP}"
+CURRENT_FABRIC_INDEX_PATH = (
+    f"0/{CLUSTER_OPERATIONAL_CREDENTIALS}/{ATTR_CURRENT_FABRIC_INDEX}"
+)
+
+
+async def _accessing_fabric_index(client: Any, node_id: int) -> int:
+    """Read the device's CurrentFabricIndex (the accessing fabric).
+
+    Fabric-scoped writes must carry the real fabric index. python-matter-server
+    coerces a 0 to the accessing fabric, but matter.js writes it literally, so a
+    hardcoded 0 lands the GroupKeyMap on fabric 0 and the device rejects AddGroup
+    with UNSUPPORTED_ACCESS. Fabric indices are 1-based; fall back to 1.
+    """
+    try:
+        value = await client.read_attribute(
+            node_id=node_id, attribute_path=CURRENT_FABRIC_INDEX_PATH
+        )
+        index = int(value)
+        if index >= 1:
+            return index
+    except (ValueError, TypeError, AttributeError) as err:
+        _LOGGER.warning(
+            "Could not read CurrentFabricIndex for node %s (%s); assuming 1",
+            node_id,
+            err,
+        )
+    return 1
 
 
 def _entry_field(entry: Any, *keys: Any) -> Any:
@@ -54,12 +83,15 @@ def merge_group_key_map(
     existing: list[Any] | None,
     group_id: int,
     key_set_id: int,
+    fabric_index: int = 1,
 ) -> list[dict[str, int]]:
     """Return the GroupKeyMap list with (group_id -> key_set_id) ensured present.
 
     Pure read-modify-write helper. Preserves existing mappings, is idempotent
     (no duplicate for the same group_id), and normalizes every entry to a plain
-    dict suitable for ``write_attribute``.
+    dict suitable for ``write_attribute``. ``fabric_index`` must be the accessing
+    fabric (see ``_accessing_fabric_index``): matter.js honours it literally, so a
+    wrong index leaves the device without a group key for the accessing fabric.
     """
     result: list[dict[str, int]] = []
     found = False
@@ -72,11 +104,17 @@ def merge_group_key_map(
         if gid == group_id:
             found = True
             ksid = key_set_id  # update to the desired key set
-        result.append({"groupId": gid, "groupKeySetID": ksid, "fabricIndex": 0})
+        result.append(
+            {"groupId": gid, "groupKeySetID": ksid, "fabricIndex": fabric_index}
+        )
 
     if not found:
         result.append(
-            {"groupId": group_id, "groupKeySetID": key_set_id, "fabricIndex": 0}
+            {
+                "groupId": group_id,
+                "groupKeySetID": key_set_id,
+                "fabricIndex": fabric_index,
+            }
         )
     return result
 
@@ -151,10 +189,13 @@ async def provision_group_key(
         )
 
         # 2. Map the group id to the key set in GroupKeyMap (read-modify-write).
+        #    The mapping must be scoped to the accessing fabric or matter.js
+        #    leaves the device without a key and rejects AddGroup.
+        fabric_index = await _accessing_fabric_index(client, node_id)
         existing = await client.read_attribute(
             node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
         )
-        updated = merge_group_key_map(existing, group_id, key_set_id)
+        updated = merge_group_key_map(existing, group_id, key_set_id, fabric_index)
         await client.write_attribute(
             node_id=node_id,
             attribute_path=GROUP_KEY_MAP_PATH,

--- a/tests/unit/test_group_keys.py
+++ b/tests/unit/test_group_keys.py
@@ -12,13 +12,14 @@ from custom_components.matter_binding_helper.matter.group_keys import (
 
 def test_merge_into_empty_map():
     result = merge_group_key_map(None, group_id=5, key_set_id=0x100)
-    assert result == [{"groupId": 5, "groupKeySetID": 0x100, "fabricIndex": 0}]
+    # Default fabric index is the accessing fabric (1-based), not 0.
+    assert result == [{"groupId": 5, "groupKeySetID": 0x100, "fabricIndex": 1}]
 
 
 def test_merge_appends_new_group():
     existing = [{"groupId": 1, "groupKeySetID": 0x100, "fabricIndex": 1}]
     result = merge_group_key_map(existing, group_id=2, key_set_id=0x101)
-    assert {"groupId": 2, "groupKeySetID": 0x101, "fabricIndex": 0} in result
+    assert {"groupId": 2, "groupKeySetID": 0x101, "fabricIndex": 1} in result
     assert any(e["groupId"] == 1 for e in result)
     assert len(result) == 2
 
@@ -26,13 +27,22 @@ def test_merge_appends_new_group():
 def test_merge_is_idempotent_for_same_group():
     existing = [{"groupId": 5, "groupKeySetID": 0x100, "fabricIndex": 1}]
     result = merge_group_key_map(existing, group_id=5, key_set_id=0x100)
-    assert result == [{"groupId": 5, "groupKeySetID": 0x100, "fabricIndex": 0}]
+    assert result == [{"groupId": 5, "groupKeySetID": 0x100, "fabricIndex": 1}]
 
 
 def test_merge_updates_key_set_for_existing_group():
     existing = [{"groupId": 5, "groupKeySetID": 0x100, "fabricIndex": 1}]
     result = merge_group_key_map(existing, group_id=5, key_set_id=0x200)
-    assert result == [{"groupId": 5, "groupKeySetID": 0x200, "fabricIndex": 0}]
+    assert result == [{"groupId": 5, "groupKeySetID": 0x200, "fabricIndex": 1}]
+
+
+def test_merge_uses_supplied_fabric_index():
+    """The accessing fabric index is honoured on every written entry."""
+    existing = [{"groupId": 1, "groupKeySetID": 0x100, "fabricIndex": 2}]
+    result = merge_group_key_map(
+        existing, group_id=2, key_set_id=0x101, fabric_index=2
+    )
+    assert all(e["fabricIndex"] == 2 for e in result)
 
 
 def test_merge_reads_chip_style_struct_entries():
@@ -45,11 +55,11 @@ def test_merge_reads_chip_style_struct_entries():
 
     existing = [FakeEntry(1, 0x100)]
     result = merge_group_key_map(existing, group_id=2, key_set_id=0x101)
-    assert {"groupId": 1, "groupKeySetID": 0x100, "fabricIndex": 0} in result
-    assert {"groupId": 2, "groupKeySetID": 0x101, "fabricIndex": 0} in result
+    assert {"groupId": 1, "groupKeySetID": 0x100, "fabricIndex": 1} in result
+    assert {"groupId": 2, "groupKeySetID": 0x101, "fabricIndex": 1} in result
 
 
 def test_merge_skips_malformed_entries():
     existing = [{"groupId": None, "groupKeySetID": 5}, {"foo": "bar"}]
     result = merge_group_key_map(existing, group_id=9, key_set_id=0x100)
-    assert result == [{"groupId": 9, "groupKeySetID": 0x100, "fabricIndex": 0}]
+    assert result == [{"groupId": 9, "groupKeySetID": 0x100, "fabricIndex": 1}]


### PR DESCRIPTION
## Context

Follow-up to #298, which added the python/matter.js backend test matrix. That PR merged with `e2e (matterjs)` still red — this fixes the failure it surfaced.

## The bug

On matter.js, the real-device groupcast e2e failed at `add_to_group`:

> `Exception: Device rejected AddGroup (status 126)` — `0x7E` = `UNSUPPORTED_ACCESS`

`AddGroup` returns `UNSUPPORTED_ACCESS` when the device has no group key mapped **for the accessing fabric**. Our `provision_group_key` wrote `GroupKeyMap` entries with a hardcoded `fabricIndex: 0`:
- **python-matter-server** (chip) coerces a `0` on a fabric-scoped write to the accessing fabric → mapping lands correctly → `AddGroup` allowed.
- **matter.js** honours the index literally → the mapping went to fabric 0, the controller's real fabric had none → `AddGroup` denied.

## The fix

Read `OperationalCredentials.CurrentFabricIndex` and write the `GroupKeyMap` with that index instead of `0`. It's the accessing fabric on both backends, so it's a **no-op for python-matter-server** and a **fix for matter.js**.

## Notes / follow-ups

- The same `fabricIndex: 0` convention is used for the **Binding** write ([bindings.py](custom_components/matter_binding_helper/matter/bindings.py)) and group-auth **ACL** entries ([acl.py](custom_components/matter_binding_helper/matter/acl.py)). Binding is a raw `write_attribute` and may hit the same wall on matter.js at the *next* e2e step; ACL goes through the high-level `set_acl_entry` command, so the server likely scopes the fabric itself. This PR fixes only the proven failure (GroupKeyMap); if `e2e (matterjs)` then advances to fail at the binding write, the identical one-line fix applies there.

## Test plan

- [x] Unit tests updated + passing (`tests/unit/test_group_keys.py`)
- [x] `make lint` clean
- [ ] `e2e (matterjs)` gets past `add_to_group` (validated by CI on this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced fabric-scoped support for Matter group key management.

* **Bug Fixes**
  * Enhanced fabric index handling to use device-reported values instead of fixed defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->