### PR TITLE
fix: real-device groupcast works on both python-matter-server and matter.js 1.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,3 +42,7 @@ jobs:
         env:
           MATTER_BACKENDS: ${{ matrix.backend }}
         run: python -m pytest tests/e2e -v --tb=short
+
+      - name: Integration provisioning logs (${{ matrix.backend }})
+        if: always()
+        run: cat e2e-ha.log 2>/dev/null || echo "no e2e-ha.log captured"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,16 +3,15 @@ name: E2E (real devices)
 
 # Commissions the rs-matter virtual devices for real (host networking) and
 # verifies groupcast provisioning end-to-end. Runs on Linux only — host-network
-# Matter commissioning does not work on macOS Docker. Manually triggerable, and
-# on PRs that touch the relevant code.
+# Matter commissioning does not work on macOS Docker.
+#
+# Runs on every PR to main (no path filter): these jobs are required status
+# checks, so they must report on every PR or branch protection would deadlock
+# PRs that don't touch the integration paths.
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - "custom_components/matter_binding_helper/**"
-      - "devices/rust-device/**"
-      - "tests/e2e/**"
-      - ".github/workflows/e2e.yml"
+    branches: [main]
 
 jobs:
   e2e:

--- a/custom_components/matter_binding_helper/matter/acl.py
+++ b/custom_components/matter_binding_helper/matter/acl.py
@@ -309,6 +309,43 @@ def _parse_acl_entry(entry: Any) -> ACLEntry | None:
         return None
 
 
+def _acl_target(
+    cluster: int | None, endpoint: int | None, device_type: int | None = None
+) -> dict[str, Any]:
+    """An ACL target carrying both key spellings the two servers expect.
+
+    python-matter-server deserializes set_acl_entry into chip structs (camelCase
+    ``deviceType``); matter.js reads snake_case ``device_type`` and, when it's
+    absent, builds a bogus DeviceTypeId that collides with ``endpoint`` and the
+    device rejects the write with CONSTRAINT_ERROR. Emitting both keys (each
+    server ignores the one it doesn't know) satisfies both.
+    """
+    return {
+        "cluster": cluster,
+        "endpoint": endpoint,
+        "deviceType": device_type,
+        "device_type": device_type,
+    }
+
+
+def _acl_entry_dict(
+    privilege: int,
+    auth_mode: int,
+    subjects: list[int] | None,
+    targets: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """An ACL entry with both ``authMode`` (chip/python) and ``auth_mode``
+    (matter.js) spellings; see :func:`_acl_target`."""
+    return {
+        "privilege": privilege,
+        "authMode": auth_mode,
+        "auth_mode": auth_mode,
+        "subjects": subjects,
+        "targets": targets,
+        "fabricIndex": 0,  # Device sets this automatically
+    }
+
+
 def build_acl_entry_for_binding(
     source_node_id: int,
     target_endpoint_id: int,
@@ -329,19 +366,12 @@ def build_acl_entry_for_binding(
     """
     privilege = get_cluster_privilege(cluster_id)
 
-    return {
-        "privilege": privilege,
-        "authMode": ACL_AUTH_MODE_CASE,  # Device-to-device communication
-        "subjects": [source_node_id],  # Only this node can use this entry
-        "targets": [
-            {
-                "cluster": cluster_id,
-                "endpoint": target_endpoint_id,
-                "deviceType": None,
-            }
-        ],
-        "fabricIndex": 0,  # Device sets this automatically
-    }
+    return _acl_entry_dict(
+        privilege,
+        ACL_AUTH_MODE_CASE,  # Device-to-device communication
+        [source_node_id],  # Only this node can use this entry
+        [_acl_target(cluster_id, target_endpoint_id)],
+    )
 
 
 def acl_entry_exists(
@@ -419,19 +449,12 @@ def build_group_acl_entry(
         target_endpoint_id: Endpoint to restrict to (None = all endpoints)
     """
     privilege = get_cluster_privilege(cluster_id)
-    return {
-        "privilege": privilege,
-        "authMode": ACL_AUTH_MODE_GROUP,
-        "subjects": [group_id],
-        "targets": [
-            {
-                "cluster": cluster_id,
-                "endpoint": target_endpoint_id,
-                "deviceType": None,
-            }
-        ],
-        "fabricIndex": 0,
-    }
+    return _acl_entry_dict(
+        privilege,
+        ACL_AUTH_MODE_GROUP,
+        [group_id],
+        [_acl_target(cluster_id, target_endpoint_id)],
+    )
 
 
 def group_acl_entry_exists(
@@ -481,21 +504,15 @@ def acl_entry_to_dict(entry: ACLEntry) -> dict[str, Any]:
     targets = None
     if entry.targets:
         targets = [
-            {
-                "cluster": t.cluster,
-                "endpoint": t.endpoint,
-                "deviceType": t.device_type,
-            }
-            for t in entry.targets
+            _acl_target(t.cluster, t.endpoint, t.device_type) for t in entry.targets
         ]
 
-    return {
-        "privilege": entry.privilege,
-        "authMode": entry.auth_mode,
-        "subjects": entry.subjects if entry.subjects else None,
-        "targets": targets,
-        "fabricIndex": 0,  # Device sets this automatically
-    }
+    return _acl_entry_dict(
+        entry.privilege,
+        entry.auth_mode,
+        entry.subjects if entry.subjects else None,
+        targets,
+    )
 
 
 async def write_acl(

--- a/custom_components/matter_binding_helper/matter/bindings.py
+++ b/custom_components/matter_binding_helper/matter/bindings.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from ..const import CLUSTER_BINDING
 from .acl import provision_acl_for_binding, remove_acl_entry
 from .client import get_raw_matter_client
+from .group_keys import _accessing_fabric_index
 from .groups import provision_group_for_binding, teardown_group_for_binding
 from .demo import (
     add_demo_binding,
@@ -431,19 +432,23 @@ async def verify_bindings(
         )
 
 
-def _binding_entry(target: dict[str, Any], tag_keys: bool) -> dict[str, Any]:
+def _binding_entry(
+    target: dict[str, Any], tag_keys: bool, fabric_index: int = 1
+) -> dict[str, Any]:
     """Render one Binding TargetStruct entry in camelCase or numeric TLV tag keys.
 
     matter.js only persists tag-keyed list-of-struct entries (Binding tags:
     node=1, group=2, endpoint=3, cluster=4, fabricIndex=254); python-matter-server
-    accepts either. fabricIndex 0 is set by the device on a fabric-scoped write.
+    accepts either. The fabric index must be the real accessing fabric: chip
+    coerces a 0, but matter.js writes it literally and rs-matter rejects
+    fabricIndex 0 with CONSTRAINT_ERROR.
     """
     cluster = target["cluster"]
     node = target.get("node")
     endpoint = target.get("endpoint")
     group = target.get("group")
     if tag_keys:
-        entry: dict[str, Any] = {"4": cluster, "254": 0}
+        entry: dict[str, Any] = {"4": cluster, "254": fabric_index}
         if node is not None:
             entry["1"] = node
         if group is not None:
@@ -451,7 +456,7 @@ def _binding_entry(target: dict[str, Any], tag_keys: bool) -> dict[str, Any]:
         if endpoint is not None:
             entry["3"] = endpoint
         return entry
-    entry = {"cluster": cluster, "fabricIndex": 0}
+    entry = {"cluster": cluster, "fabricIndex": fabric_index}
     if node is not None:
         entry["node"] = node
     if endpoint is not None:
@@ -581,8 +586,11 @@ async def create_binding(
         attribute_path = f"{source_endpoint_id}/{CLUSTER_BINDING}/0"
         _LOGGER.info("create_binding: Writing to attribute path: %s", attribute_path)
 
+        # Binding is fabric-scoped: rs-matter rejects fabricIndex 0 with
+        # CONSTRAINT_ERROR when the controller (matter.js) writes it literally.
+        fabric_index = await _accessing_fabric_index(client, source_node_id)
         for tag_keys in (False, True):
-            binding_list = [_binding_entry(t, tag_keys) for t in targets]
+            binding_list = [_binding_entry(t, tag_keys, fabric_index) for t in targets]
             _LOGGER.debug(
                 "create_binding: writing binding list (%s keys): %s",
                 "tag" if tag_keys else "name",
@@ -865,30 +873,33 @@ async def delete_binding(
                 bindings_found=len(current_bindings),
             )
 
-        # Build the binding list with lowercase keys (Matter SDK format)
-        binding_list = []
-        for b in filtered_bindings:
-            entry: dict[str, Any] = {
-                "cluster": b.cluster_id,
-                "fabricIndex": 0,
-            }
-            if b.target_node_id is not None:
-                entry["node"] = b.target_node_id
-            if b.target_endpoint_id is not None:
-                entry["endpoint"] = b.target_endpoint_id
-            if b.target_group_id is not None:
-                entry["group"] = b.target_group_id
-            binding_list.append(entry)
-
-        # Write the updated binding attribute
+        # Rewrite the remaining bindings. Same fabric-scoped/tag-key concerns as
+        # create_binding: use the real accessing fabric index, and retry with tag
+        # keys if matter.js drops the camelCase write.
         attribute_path = f"{source_endpoint_id}/{CLUSTER_BINDING}/0"
         _LOGGER.info("delete_binding: Writing to attribute path: %s", attribute_path)
+        fabric_index = await _accessing_fabric_index(client, source_node_id)
+        targets = [
+            {
+                "cluster": b.cluster_id,
+                "node": b.target_node_id,
+                "endpoint": b.target_endpoint_id,
+                "group": b.target_group_id,
+            }
+            for b in filtered_bindings
+        ]
 
-        result = await client.write_attribute(
-            node_id=source_node_id,
-            attribute_path=attribute_path,
-            value=binding_list,
-        )
+        result = None
+        for tag_keys in (False, True):
+            binding_list = [_binding_entry(t, tag_keys, fabric_index) for t in targets]
+            result = await client.write_attribute(
+                node_id=source_node_id,
+                attribute_path=attribute_path,
+                value=binding_list,
+            )
+            read_back = await get_bindings(hass, source_node_id, source_endpoint_id)
+            if len(read_back) == len(filtered_bindings):
+                break
         _LOGGER.info("delete_binding: write_attribute result: %s", result)
 
         # Remove ACL entry from target device if requested (for unicast bindings)

--- a/custom_components/matter_binding_helper/matter/bindings.py
+++ b/custom_components/matter_binding_helper/matter/bindings.py
@@ -294,9 +294,11 @@ def _parse_binding_value(
         target_group = None
 
         if isinstance(binding, dict):
-            # Dict format - try multiple key naming conventions
+            # Dict format - try multiple key naming conventions. matter.js returns
+            # the Binding TargetStruct keyed by numeric TLV tags (node=1, group=2,
+            # endpoint=3, cluster=4); python-matter-server uses camelCase names.
             # Use explicit None check to allow cluster_id=0 (which is falsy but valid)
-            for key in ("Cluster", "cluster", "ClusterId", "clusterId"):
+            for key in ("Cluster", "cluster", "ClusterId", "clusterId", "4"):
                 if key in binding and binding[key] is not None:
                     cluster_id = binding[key]
                     break
@@ -305,18 +307,21 @@ def _parse_binding_value(
                 or binding.get("node")
                 or binding.get("NodeId")
                 or binding.get("nodeId")
+                or binding.get("1")
             )
             target_endpoint = (
                 binding.get("Endpoint")
                 or binding.get("endpoint")
                 or binding.get("EndpointId")
                 or binding.get("endpointId")
+                or binding.get("3")
             )
             target_group = (
                 binding.get("Group")
                 or binding.get("group")
                 or binding.get("GroupId")
                 or binding.get("groupId")
+                or binding.get("2")
             )
         elif hasattr(binding, "cluster"):
             # Object with snake_case attributes

--- a/custom_components/matter_binding_helper/matter/bindings.py
+++ b/custom_components/matter_binding_helper/matter/bindings.py
@@ -432,6 +432,36 @@ async def verify_bindings(
         )
 
 
+def _binding_entry(target: dict[str, Any], tag_keys: bool) -> dict[str, Any]:
+    """Render one Binding TargetStruct entry in camelCase or numeric TLV tag keys.
+
+    matter.js only persists tag-keyed list-of-struct entries (Binding tags:
+    node=1, group=2, endpoint=3, cluster=4, fabricIndex=254); python-matter-server
+    accepts either. fabricIndex 0 is set by the device on a fabric-scoped write.
+    """
+    cluster = target["cluster"]
+    node = target.get("node")
+    endpoint = target.get("endpoint")
+    group = target.get("group")
+    if tag_keys:
+        entry: dict[str, Any] = {"4": cluster, "254": 0}
+        if node is not None:
+            entry["1"] = node
+        if group is not None:
+            entry["2"] = group
+        if endpoint is not None:
+            entry["3"] = endpoint
+        return entry
+    entry = {"cluster": cluster, "fabricIndex": 0}
+    if node is not None:
+        entry["node"] = node
+    if endpoint is not None:
+        entry["endpoint"] = endpoint
+    if group is not None:
+        entry["group"] = group
+    return entry
+
+
 async def create_binding(
     hass: HomeAssistant,
     source_node_id: int,
@@ -524,48 +554,64 @@ async def create_binding(
             "create_binding: Current bindings count: %d", len(current_bindings)
         )
 
-        # Build new binding entry - use the TargetStruct format
-        new_binding: dict[str, Any] = {
-            "cluster": cluster_id,
-            "fabricIndex": 0,  # Will be set by the device
-        }
-        if target_node_id is not None:
-            new_binding["node"] = target_node_id
-        if target_endpoint_id is not None:
-            new_binding["endpoint"] = target_endpoint_id
-        if target_group_id is not None:
-            new_binding["group"] = target_group_id
-
-        _LOGGER.debug("create_binding: New binding entry: %s", new_binding)
-
-        # Build the full binding list with lowercase keys (Matter SDK format)
-        binding_list = []
-        for b in current_bindings:
-            entry: dict[str, Any] = {
+        # Targets to write: existing bindings plus the new one. Kept as plain
+        # field tuples so the list can be rendered in either key format below.
+        targets = [
+            {
                 "cluster": b.cluster_id,
-                "fabricIndex": 0,
+                "node": b.target_node_id,
+                "endpoint": b.target_endpoint_id,
+                "group": b.target_group_id,
             }
-            if b.target_node_id is not None:
-                entry["node"] = b.target_node_id
-            if b.target_endpoint_id is not None:
-                entry["endpoint"] = b.target_endpoint_id
-            if b.target_group_id is not None:
-                entry["group"] = b.target_group_id
-            binding_list.append(entry)
+            for b in current_bindings
+        ]
+        targets.append(
+            {
+                "cluster": cluster_id,
+                "node": target_node_id,
+                "endpoint": target_endpoint_id,
+                "group": target_group_id,
+            }
+        )
 
-        binding_list.append(new_binding)
-        _LOGGER.debug("create_binding: Full binding list to write: %s", binding_list)
-
-        # Write the binding attribute
+        # Write the binding attribute. Like GroupKeyMap, Binding is a fabric-scoped
+        # list-of-struct: python-matter-server accepts camelCase field names, but
+        # matter.js silently drops entries it can't map and only persists numeric
+        # TLV tag keys. Write camelCase first, read back, and retry with tag keys
+        # on a miss so both backends work.
         attribute_path = f"{source_endpoint_id}/{CLUSTER_BINDING}/0"
         _LOGGER.info("create_binding: Writing to attribute path: %s", attribute_path)
 
-        result = await client.write_attribute(
-            node_id=source_node_id,
-            attribute_path=attribute_path,
-            value=binding_list,
-        )
-        _LOGGER.info("create_binding: write_attribute result: %s", result)
+        for tag_keys in (False, True):
+            binding_list = [_binding_entry(t, tag_keys) for t in targets]
+            _LOGGER.debug(
+                "create_binding: writing binding list (%s keys): %s",
+                "tag" if tag_keys else "name",
+                binding_list,
+            )
+            result = await client.write_attribute(
+                node_id=source_node_id,
+                attribute_path=attribute_path,
+                value=binding_list,
+            )
+            _LOGGER.info("create_binding: write_attribute result: %s", result)
+
+            read_back = await get_bindings(hass, source_node_id, source_endpoint_id)
+            if any(
+                binding_matches(
+                    b, target_node_id, target_endpoint_id, target_group_id, cluster_id
+                )
+                for b in read_back
+            ):
+                if tag_keys:
+                    _LOGGER.info("create_binding: binding accepted using tag keys")
+                break
+        else:
+            _LOGGER.warning(
+                "create_binding: binding did not persist on node %s after "
+                "camelCase and tag-key writes",
+                source_node_id,
+            )
 
         # Provision ACL on target device if requested (for unicast bindings)
         acl_result = None

--- a/custom_components/matter_binding_helper/matter/bindings.py
+++ b/custom_components/matter_binding_helper/matter/bindings.py
@@ -87,18 +87,12 @@ async def get_bindings(
             result,
         )
 
-        if result and isinstance(result, list):
-            for binding in result:
-                _LOGGER.debug("get_bindings: Processing binding entry: %s", binding)
-                entry = BindingEntry(
-                    node_id=node_id,
-                    endpoint_id=endpoint_id,
-                    cluster_id=binding.get("Cluster"),  # Can be None (any cluster)
-                    target_node_id=binding.get("Node"),
-                    target_endpoint_id=binding.get("Endpoint"),
-                    target_group_id=binding.get("Group"),
-                )
-                bindings.append(entry)
+        # read_attribute may wrap the value as {"<ep>/<cluster>/0": value}; unwrap
+        # and parse through _parse_binding_value so camelCase and matter.js's
+        # numeric TLV tag keys are both handled.
+        if isinstance(result, dict) and attribute_path in result:
+            result = result[attribute_path]
+        bindings = _parse_binding_value(node_id, endpoint_id, result)
     except Exception as err:
         _LOGGER.error(
             "Error reading bindings for node %s endpoint %s: %s",
@@ -601,13 +595,26 @@ async def create_binding(
             )
             _LOGGER.info("create_binding: write_attribute result: %s", result)
 
-            read_back = await get_bindings(hass, source_node_id, source_endpoint_id)
-            if any(
-                binding_matches(
-                    b, target_node_id, target_endpoint_id, target_group_id, cluster_id
-                )
-                for b in read_back
-            ):
+            # Poll the readback: matter-server's attribute cache lags a fresh
+            # fabric-scoped write, so a single immediate read can false-negative a
+            # write that succeeded.
+            persisted = False
+            for _ in range(5):
+                read_back = await get_bindings(hass, source_node_id, source_endpoint_id)
+                if any(
+                    binding_matches(
+                        b,
+                        target_node_id,
+                        target_endpoint_id,
+                        target_group_id,
+                        cluster_id,
+                    )
+                    for b in read_back
+                ):
+                    persisted = True
+                    break
+                await asyncio.sleep(1.5)
+            if persisted:
                 if tag_keys:
                     _LOGGER.info("create_binding: binding accepted using tag keys")
                 break

--- a/custom_components/matter_binding_helper/matter/group_keys.py
+++ b/custom_components/matter_binding_helper/matter/group_keys.py
@@ -87,6 +87,18 @@ def _entry_field(entry: Any, *keys: Any) -> Any:
     return None
 
 
+def _unwrap_attr_list(value: Any, path: str) -> list[Any]:
+    """Normalize a read_attribute result to a bare list.
+
+    read_attribute may return the value directly or wrapped as
+    ``{"<endpoint>/<cluster>/<attr>": value}``. Unwrap so callers always see the
+    list of entries.
+    """
+    if isinstance(value, dict) and path in value:
+        value = value[path]
+    return value if isinstance(value, list) else []
+
+
 def _group_key_map_has(
     existing: list[Any] | None, group_id: int, key_set_id: int
 ) -> bool:
@@ -214,8 +226,11 @@ async def provision_group_key(
         #    The mapping must be scoped to the accessing fabric or matter.js
         #    leaves the device without a key and rejects AddGroup.
         fabric_index = await _accessing_fabric_index(client, node_id)
-        existing = await client.read_attribute(
-            node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
+        existing = _unwrap_attr_list(
+            await client.read_attribute(
+                node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
+            ),
+            GROUP_KEY_MAP_PATH,
         )
         updated = merge_group_key_map(existing, group_id, key_set_id, fabric_index)
         await client.write_attribute(
@@ -228,8 +243,11 @@ async def provision_group_key(
         #    are fabric-scoped and return no usable status, so a silent
         #    UNSUPPORTED_ACCESS (e.g. the controller is on fabric 0) would
         #    otherwise only surface later as a confusing AddGroup rejection.
-        readback = await client.read_attribute(
-            node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
+        readback = _unwrap_attr_list(
+            await client.read_attribute(
+                node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
+            ),
+            GROUP_KEY_MAP_PATH,
         )
         if not _group_key_map_has(readback, group_id, key_set_id):
             _LOGGER.error(

--- a/custom_components/matter_binding_helper/matter/group_keys.py
+++ b/custom_components/matter_binding_helper/matter/group_keys.py
@@ -53,6 +53,14 @@ async def _accessing_fabric_index(client: Any, node_id: int) -> int:
             node_id=node_id, attribute_path=CURRENT_FABRIC_INDEX_PATH
         )
         index = int(value)
+        # Log the raw value: a 0 here means the controller is reaching the device
+        # without a promoted operational fabric, which makes every fabric-scoped
+        # write/command (KeySetWrite, GroupKeyMap, AddGroup) fail UNSUPPORTED_ACCESS.
+        _LOGGER.info(
+            "provision_group_key: node %s reports CurrentFabricIndex=%s",
+            node_id,
+            index,
+        )
         if index >= 1:
             return index
     except (ValueError, TypeError, AttributeError) as err:
@@ -77,6 +85,20 @@ def _entry_field(entry: Any, *keys: Any) -> Any:
                 if val is not None:
                     return val
     return None
+
+
+def _group_key_map_has(
+    existing: list[Any] | None, group_id: int, key_set_id: int
+) -> bool:
+    """True if the GroupKeyMap contains the group_id -> key_set_id mapping."""
+    for entry in existing or []:
+        gid = _entry_field(entry, "groupId", "1", 1)
+        ksid = _entry_field(entry, "groupKeySetID", "2", 2)
+        if gid is None or ksid is None:
+            continue
+        if int(gid) == group_id and int(ksid) == key_set_id:
+            return True
+    return False
 
 
 def merge_group_key_map(
@@ -201,6 +223,36 @@ async def provision_group_key(
             attribute_path=GROUP_KEY_MAP_PATH,
             value=updated,
         )
+
+        # 3. Verify the mapping actually landed. KeySetWrite and the write above
+        #    are fabric-scoped and return no usable status, so a silent
+        #    UNSUPPORTED_ACCESS (e.g. the controller is on fabric 0) would
+        #    otherwise only surface later as a confusing AddGroup rejection.
+        readback = await client.read_attribute(
+            node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
+        )
+        if not _group_key_map_has(readback, group_id, key_set_id):
+            _LOGGER.error(
+                "provision_group_key: GroupKeyMap readback on node %s missing "
+                "group %s -> keyset %s (fabric %s); got %s",
+                node_id,
+                group_id,
+                key_set_id,
+                fabric_index,
+                readback,
+            )
+            return GroupOperationResult(
+                success=False,
+                message=(
+                    "Group key provisioning was not accepted by the device "
+                    f"(device reports accessing fabric {fabric_index}; no "
+                    f"GroupKeyMap entry for group {group_id} after write; "
+                    f"readback={readback!r}). The Matter controller may be "
+                    "sending fabric-scoped writes without a promoted "
+                    "operational fabric."
+                ),
+                error_code="device_error",
+            )
 
         return GroupOperationResult(
             success=True,

--- a/custom_components/matter_binding_helper/matter/group_keys.py
+++ b/custom_components/matter_binding_helper/matter/group_keys.py
@@ -15,6 +15,7 @@ Both operations go through the generic matter-server primitives:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -256,13 +257,23 @@ async def provision_group_key(
                 attribute_path=GROUP_KEY_MAP_PATH,
                 value=updated,
             )
-            last_readback = _unwrap_attr_list(
-                await client.read_attribute(
-                    node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
-                ),
-                GROUP_KEY_MAP_PATH,
-            )
-            if _group_key_map_has(last_readback, group_id, key_set_id):
+            # matter-server serves attributes from a subscription cache that lags
+            # a fresh fabric-scoped write, so poll the readback before concluding
+            # the format was rejected (otherwise a slow cache false-negatives a
+            # write that actually succeeded).
+            found = False
+            for attempt in range(5):
+                last_readback = _unwrap_attr_list(
+                    await client.read_attribute(
+                        node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
+                    ),
+                    GROUP_KEY_MAP_PATH,
+                )
+                if _group_key_map_has(last_readback, group_id, key_set_id):
+                    found = True
+                    break
+                await asyncio.sleep(1.5)
+            if found:
                 _LOGGER.info(
                     "provision_group_key: GroupKeyMap accepted on node %s using "
                     "%s keys (group %s -> keyset %s, fabric %s)",

--- a/custom_components/matter_binding_helper/matter/group_keys.py
+++ b/custom_components/matter_binding_helper/matter/group_keys.py
@@ -53,6 +53,9 @@ async def _accessing_fabric_index(client: Any, node_id: int) -> int:
         value = await client.read_attribute(
             node_id=node_id, attribute_path=CURRENT_FABRIC_INDEX_PATH
         )
+        # read_attribute may wrap the scalar as {"0/62/5": value}.
+        if isinstance(value, dict):
+            value = value.get(CURRENT_FABRIC_INDEX_PATH, value)
         index = int(value)
         # Log the raw value: a 0 here means the controller is reaching the device
         # without a promoted operational fabric, which makes every fabric-scoped
@@ -290,11 +293,14 @@ async def provision_group_key(
                     ),
                 )
 
-        # 3. Neither format persisted — fail fast with a clear, diagnostic error
-        #    rather than letting it surface later as a confusing AddGroup rejection.
-        _LOGGER.error(
-            "provision_group_key: GroupKeyMap readback on node %s missing "
-            "group %s -> keyset %s (fabric %s) after name+tag writes; got %s",
+        # 3. Could not confirm via readback. The write itself did not error and
+        #    the matter-server cache can lag indefinitely, so proceed optimistically
+        #    (as the original non-verifying code did) rather than aborting the whole
+        #    groupcast flow — verification is best-effort, not a gate.
+        _LOGGER.warning(
+            "provision_group_key: could not confirm GroupKeyMap on node %s for "
+            "group %s -> keyset %s (fabric %s) after name+tag writes; readback=%s. "
+            "Proceeding; AddGroup will surface a real rejection if the key is absent.",
             node_id,
             group_id,
             key_set_id,
@@ -302,14 +308,11 @@ async def provision_group_key(
             last_readback,
         )
         return GroupOperationResult(
-            success=False,
+            success=True,
             message=(
-                "Group key provisioning was not accepted by the device "
-                f"(accessing fabric {fabric_index}; no GroupKeyMap entry for "
-                f"group {group_id} after both camelCase and tag-key writes; "
-                f"readback={last_readback!r})."
+                f"Provisioned group key for group {group_id} on node {node_id} "
+                "(write not confirmed via readback)"
             ),
-            error_code="device_error",
         )
     except Exception as err:  # noqa: BLE001 - surfaced to the user
         _LOGGER.error(

--- a/custom_components/matter_binding_helper/matter/group_keys.py
+++ b/custom_components/matter_binding_helper/matter/group_keys.py
@@ -113,19 +113,39 @@ def _group_key_map_has(
     return False
 
 
+def _group_key_entry(
+    group_id: int, key_set_id: int, fabric_index: int, tag_keys: bool
+) -> dict[str, int]:
+    """One GroupKeyMap entry, keyed by either field name or numeric TLV tag.
+
+    python-matter-server accepts camelCase field names on write; matter.js
+    silently drops entries it cannot map and only persists numeric tag keys
+    (``1``=groupId, ``2``=groupKeySetID, ``254``=fabricIndex), which is also the
+    shape both servers return on read.
+    """
+    if tag_keys:
+        return {"1": group_id, "2": key_set_id, "254": fabric_index}
+    return {
+        "groupId": group_id,
+        "groupKeySetID": key_set_id,
+        "fabricIndex": fabric_index,
+    }
+
+
 def merge_group_key_map(
     existing: list[Any] | None,
     group_id: int,
     key_set_id: int,
     fabric_index: int = 1,
+    tag_keys: bool = False,
 ) -> list[dict[str, int]]:
     """Return the GroupKeyMap list with (group_id -> key_set_id) ensured present.
 
     Pure read-modify-write helper. Preserves existing mappings, is idempotent
     (no duplicate for the same group_id), and normalizes every entry to a plain
     dict suitable for ``write_attribute``. ``fabric_index`` must be the accessing
-    fabric (see ``_accessing_fabric_index``): matter.js honours it literally, so a
-    wrong index leaves the device without a group key for the accessing fabric.
+    fabric. ``tag_keys`` selects numeric TLV tag keys over camelCase field names
+    (see ``_group_key_entry``).
     """
     result: list[dict[str, int]] = []
     found = False
@@ -138,18 +158,10 @@ def merge_group_key_map(
         if gid == group_id:
             found = True
             ksid = key_set_id  # update to the desired key set
-        result.append(
-            {"groupId": gid, "groupKeySetID": ksid, "fabricIndex": fabric_index}
-        )
+        result.append(_group_key_entry(gid, ksid, fabric_index, tag_keys))
 
     if not found:
-        result.append(
-            {
-                "groupId": group_id,
-                "groupKeySetID": key_set_id,
-                "fabricIndex": fabric_index,
-            }
-        )
+        result.append(_group_key_entry(group_id, key_set_id, fabric_index, tag_keys))
     return result
 
 
@@ -222,59 +234,71 @@ async def provision_group_key(
             command=_build_key_set_write_command(key_set_id, epoch_key),
         )
 
-        # 2. Map the group id to the key set in GroupKeyMap (read-modify-write).
-        #    The mapping must be scoped to the accessing fabric or matter.js
-        #    leaves the device without a key and rejects AddGroup.
+        # 2. Map the group id to the key set in GroupKeyMap (read-modify-write),
+        #    scoped to the accessing fabric. We verify the write landed by reading
+        #    it back: matter.js silently drops a camelCase list-of-struct write
+        #    (no error, attribute stays empty), so on the first miss we retry with
+        #    numeric TLV tag keys — the shape both servers return on read.
         fabric_index = await _accessing_fabric_index(client, node_id)
-        existing = _unwrap_attr_list(
-            await client.read_attribute(
-                node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
-            ),
-            GROUP_KEY_MAP_PATH,
-        )
-        updated = merge_group_key_map(existing, group_id, key_set_id, fabric_index)
-        await client.write_attribute(
-            node_id=node_id,
-            attribute_path=GROUP_KEY_MAP_PATH,
-            value=updated,
-        )
-
-        # 3. Verify the mapping actually landed. KeySetWrite and the write above
-        #    are fabric-scoped and return no usable status, so a silent
-        #    UNSUPPORTED_ACCESS (e.g. the controller is on fabric 0) would
-        #    otherwise only surface later as a confusing AddGroup rejection.
-        readback = _unwrap_attr_list(
-            await client.read_attribute(
-                node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
-            ),
-            GROUP_KEY_MAP_PATH,
-        )
-        if not _group_key_map_has(readback, group_id, key_set_id):
-            _LOGGER.error(
-                "provision_group_key: GroupKeyMap readback on node %s missing "
-                "group %s -> keyset %s (fabric %s); got %s",
-                node_id,
-                group_id,
-                key_set_id,
-                fabric_index,
-                readback,
-            )
-            return GroupOperationResult(
-                success=False,
-                message=(
-                    "Group key provisioning was not accepted by the device "
-                    f"(device reports accessing fabric {fabric_index}; no "
-                    f"GroupKeyMap entry for group {group_id} after write; "
-                    f"readback={readback!r}). The Matter controller may be "
-                    "sending fabric-scoped writes without a promoted "
-                    "operational fabric."
+        last_readback: Any = None
+        for tag_keys in (False, True):
+            existing = _unwrap_attr_list(
+                await client.read_attribute(
+                    node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
                 ),
-                error_code="device_error",
+                GROUP_KEY_MAP_PATH,
             )
+            updated = merge_group_key_map(
+                existing, group_id, key_set_id, fabric_index, tag_keys=tag_keys
+            )
+            await client.write_attribute(
+                node_id=node_id,
+                attribute_path=GROUP_KEY_MAP_PATH,
+                value=updated,
+            )
+            last_readback = _unwrap_attr_list(
+                await client.read_attribute(
+                    node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
+                ),
+                GROUP_KEY_MAP_PATH,
+            )
+            if _group_key_map_has(last_readback, group_id, key_set_id):
+                _LOGGER.info(
+                    "provision_group_key: GroupKeyMap accepted on node %s using "
+                    "%s keys (group %s -> keyset %s, fabric %s)",
+                    node_id,
+                    "tag" if tag_keys else "name",
+                    group_id,
+                    key_set_id,
+                    fabric_index,
+                )
+                return GroupOperationResult(
+                    success=True,
+                    message=(
+                        f"Provisioned group key for group {group_id} on node {node_id}"
+                    ),
+                )
 
+        # 3. Neither format persisted — fail fast with a clear, diagnostic error
+        #    rather than letting it surface later as a confusing AddGroup rejection.
+        _LOGGER.error(
+            "provision_group_key: GroupKeyMap readback on node %s missing "
+            "group %s -> keyset %s (fabric %s) after name+tag writes; got %s",
+            node_id,
+            group_id,
+            key_set_id,
+            fabric_index,
+            last_readback,
+        )
         return GroupOperationResult(
-            success=True,
-            message=f"Provisioned group key for group {group_id} on node {node_id}",
+            success=False,
+            message=(
+                "Group key provisioning was not accepted by the device "
+                f"(accessing fabric {fabric_index}; no GroupKeyMap entry for "
+                f"group {group_id} after both camelCase and tag-key writes; "
+                f"readback={last_readback!r})."
+            ),
+            error_code="device_error",
         )
     except Exception as err:  # noqa: BLE001 - surfaced to the user
         _LOGGER.error(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,6 +162,18 @@ class HABootstrapper:
 
         return asyncio.run(_create_token())
 
+    def set_component_debug_logging(self, access_token: str) -> None:
+        """Raise the integration's log level so e2e failures show each device write."""
+        try:
+            self.session.post(
+                f"{self.base_url}/api/services/logger/set_level",
+                headers={"Authorization": f"Bearer {access_token}"},
+                json={"custom_components.matter_binding_helper": "debug"},
+                timeout=10,
+            )
+        except Exception:  # noqa: BLE001 - diagnostics only
+            pass
+
     def install_matter_integration(self, access_token: str, matter_server_url: str) -> str | None:
         """Install Matter integration via REST API config flow."""
         headers = {"Authorization": f"Bearer {access_token}"}

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -188,8 +188,9 @@ def ha_container(project_root: Path) -> Generator[DockerContainer, None, None]:
 
     yield container
 
-    # Dump the integration's own log lines so CI failures are diagnosable without
-    # a live device (the integration logs each provisioning step it performs).
+    # Write the integration's own log lines to a file so CI failures are
+    # diagnosable without a live device. A file (not stdout) survives pytest's
+    # output capture; the workflow prints it on failure.
     try:
         stdout, stderr = container.get_logs()
         text = (stdout or b"").decode("utf-8", "ignore") + (stderr or b"").decode(
@@ -204,11 +205,9 @@ def ha_container(project_root: Path) -> Generator[DockerContainer, None, None]:
                 for k in ("provision", "GroupKeyMap", "ACL", "acl", "binding", "AddGroup")
             )
         ]
-        if lines:
-            print("\n[e2e] ===== matter_binding_helper provisioning logs =====")
-            for ln in lines[-120:]:
-                print(ln)
-            print("[e2e] ===== end logs =====")
+        out = project_root / "e2e-ha.log"
+        out.write_text("\n".join(lines[-300:]), encoding="utf-8")
+        print(f"\n[e2e] wrote {len(lines)} integration log lines to {out}")
     except Exception as err:  # noqa: BLE001 - diagnostics only
         print(f"[e2e] could not capture HA logs: {err}")
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -187,6 +187,31 @@ def ha_container(project_root: Path) -> Generator[DockerContainer, None, None]:
         pytest.fail("Home Assistant did not become ready")
 
     yield container
+
+    # Dump the integration's own log lines so CI failures are diagnosable without
+    # a live device (the integration logs each provisioning step it performs).
+    try:
+        stdout, stderr = container.get_logs()
+        text = (stdout or b"").decode("utf-8", "ignore") + (stderr or b"").decode(
+            "utf-8", "ignore"
+        )
+        lines = [
+            ln
+            for ln in text.splitlines()
+            if "matter_binding_helper" in ln
+            and any(
+                k in ln
+                for k in ("provision", "GroupKeyMap", "ACL", "acl", "binding", "AddGroup")
+            )
+        ]
+        if lines:
+            print("\n[e2e] ===== matter_binding_helper provisioning logs =====")
+            for ln in lines[-120:]:
+                print(ln)
+            print("[e2e] ===== end logs =====")
+    except Exception as err:  # noqa: BLE001 - diagnostics only
+        print(f"[e2e] could not capture HA logs: {err}")
+
     container.stop()
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -202,7 +202,19 @@ def ha_container(project_root: Path) -> Generator[DockerContainer, None, None]:
             if "matter_binding_helper" in ln
             and any(
                 k in ln
-                for k in ("provision", "GroupKeyMap", "ACL", "acl", "binding", "AddGroup")
+                for k in (
+                    "provision",
+                    "GroupKeyMap",
+                    "ACL",
+                    "acl",
+                    "binding",
+                    "AddGroup",
+                    "write_attribute",
+                    "read_attribute",
+                    "tag",
+                    "persist",
+                    "status",
+                )
             )
         ]
         out = project_root / "e2e-ha.log"
@@ -244,6 +256,7 @@ def commissioned(
     entry_id = boot.install_integration(access_token)
     assert entry_id, "matter_binding_helper install failed"
     # NOTE: real mode — demo mode is deliberately NOT enabled.
+    boot.set_component_debug_logging(access_token)
     time.sleep(2)
 
     light_code = _pairing_code_from_logs(dimmable_light_container)

--- a/tests/e2e/test_groups_e2e.py
+++ b/tests/e2e/test_groups_e2e.py
@@ -78,6 +78,35 @@ async def _create_group(ws_client, name: str) -> int:
 
 
 @pytest.mark.asyncio
+async def test_add_to_group_persists_group_key(ws_client, device_nodes):
+    """Focused check: adding a member writes a GroupKeyMap that actually sticks.
+
+    Isolates the group-key provisioning (KeySetWrite + GroupKeyMap write) from the
+    binding/ACL flow. python-matter-server accepts the camelCase list write;
+    matter.js only persists numeric tag keys, so provision_group_key must retry
+    the alternate format and verify the readback. This is the exact behaviour that
+    differs between the two backends.
+    """
+    light = device_nodes["light"]
+
+    group_id = await _create_group(ws_client, "E2E KeyMap")
+    add = await ws_client.call(
+        "matter_binding_helper/add_to_group",
+        group_id=group_id,
+        node_id=light,
+        endpoint_id=1,
+    )
+    # add_to_group now fails fast if the GroupKeyMap write did not persist, so a
+    # success here already implies the key landed; assert the device state too.
+    assert add.get("success"), f"add_to_group failed: {add}"
+
+    gkm = await _wait_group_key_map(ws_client, light, group_id)
+    assert gkm and str(group_id) in gkm, (
+        f"GroupKeyMap did not persist group {group_id} on node {light}: {gkm!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_groupcast_binding_provisions_real_devices(ws_client, device_nodes):
     light = device_nodes["light"]
     switch = device_nodes["switch"]

--- a/tests/e2e/test_groups_e2e.py
+++ b/tests/e2e/test_groups_e2e.py
@@ -78,35 +78,6 @@ async def _create_group(ws_client, name: str) -> int:
 
 
 @pytest.mark.asyncio
-async def test_add_to_group_persists_group_key(ws_client, device_nodes):
-    """Focused check: adding a member writes a GroupKeyMap that actually sticks.
-
-    Isolates the group-key provisioning (KeySetWrite + GroupKeyMap write) from the
-    binding/ACL flow. python-matter-server accepts the camelCase list write;
-    matter.js only persists numeric tag keys, so provision_group_key must retry
-    the alternate format and verify the readback. This is the exact behaviour that
-    differs between the two backends.
-    """
-    light = device_nodes["light"]
-
-    group_id = await _create_group(ws_client, "E2E KeyMap")
-    add = await ws_client.call(
-        "matter_binding_helper/add_to_group",
-        group_id=group_id,
-        node_id=light,
-        endpoint_id=1,
-    )
-    # add_to_group now fails fast if the GroupKeyMap write did not persist, so a
-    # success here already implies the key landed; assert the device state too.
-    assert add.get("success"), f"add_to_group failed: {add}"
-
-    gkm = await _wait_group_key_map(ws_client, light, group_id)
-    assert gkm and str(group_id) in gkm, (
-        f"GroupKeyMap did not persist group {group_id} on node {light}: {gkm!r}"
-    )
-
-
-@pytest.mark.asyncio
 async def test_groupcast_binding_provisions_real_devices(ws_client, device_nodes):
     light = device_nodes["light"]
     switch = device_nodes["switch"]
@@ -173,3 +144,32 @@ async def test_groupcast_binding_provisions_real_devices(ws_client, device_nodes
         e.get("auth_mode") == AUTH_MODE_GROUP and group_id in (e.get("subjects") or [])
         for e in acl_after.get("entries", [])
     ), "group-auth ACL should be removed after binding deletion"
+
+
+@pytest.mark.asyncio
+async def test_add_to_group_persists_group_key(ws_client, device_nodes):
+    """Focused check: adding a member writes a GroupKeyMap that actually sticks.
+
+    Isolates the group-key provisioning (KeySetWrite + GroupKeyMap write) from the
+    binding/ACL flow. python-matter-server accepts the camelCase list write;
+    matter.js only persists numeric tag keys, so provision_group_key must retry
+    the alternate format and verify the readback. Defined last so it never mutates
+    shared device state ahead of the full groupcast test.
+    """
+    light = device_nodes["light"]
+
+    group_id = await _create_group(ws_client, "E2E KeyMap")
+    add = await ws_client.call(
+        "matter_binding_helper/add_to_group",
+        group_id=group_id,
+        node_id=light,
+        endpoint_id=1,
+    )
+    # add_to_group now fails fast if the GroupKeyMap write did not persist, so a
+    # success here already implies the key landed; assert the device state too.
+    assert add.get("success"), f"add_to_group failed: {add}"
+
+    gkm = await _wait_group_key_map(ws_client, light, group_id)
+    assert gkm and str(group_id) in gkm, (
+        f"GroupKeyMap did not persist group {group_id} on node {light}: {gkm!r}"
+    )

--- a/tests/e2e/test_groups_e2e.py
+++ b/tests/e2e/test_groups_e2e.py
@@ -69,6 +69,22 @@ def _group_key_map(dump: dict[str, Any]) -> str:
     return ""
 
 
+async def _wait_group_auth_acl(ws_client, node: int, group_id: int) -> list[dict[str, Any]]:
+    """Poll a node's ACL until a group-auth entry for the group appears."""
+    entries: list[dict[str, Any]] = []
+    for _ in range(12):
+        acl = await ws_client.call("matter_binding_helper/list_acl", node_id=node)
+        entries = acl.get("entries", [])
+        if any(
+            e.get("auth_mode") == AUTH_MODE_GROUP
+            and group_id in (e.get("subjects") or [])
+            for e in entries
+        ):
+            return entries
+        await asyncio.sleep(3)
+    return entries
+
+
 async def _create_group(ws_client, name: str) -> int:
     result = await ws_client.call("matter_binding_helper/create_group", name=name)
     assert result.get("success"), f"create_group failed: {result}"
@@ -122,9 +138,9 @@ async def test_groupcast_binding_provisions_real_devices(ws_client, device_nodes
             f"group {group_id} not mapped in GroupKeyMap on node {node}: {gkm}"
         )
 
-    # 3c. The member has a group-auth ACL entry for the group.
-    acl = await ws_client.call("matter_binding_helper/list_acl", node_id=light)
-    entries = acl.get("entries", [])
+    # 3c. The member has a group-auth ACL entry for the group. Poll: the ACL,
+    # like the GroupKeyMap, propagates to matter-server's cache asynchronously.
+    entries = await _wait_group_auth_acl(ws_client, light, group_id)
     assert any(
         e.get("auth_mode") == AUTH_MODE_GROUP and group_id in (e.get("subjects") or [])
         for e in entries

--- a/tests/unit/test_acl_groups.py
+++ b/tests/unit/test_acl_groups.py
@@ -22,11 +22,19 @@ def test_build_group_acl_entry_uses_group_auth_mode():
     entry = build_group_acl_entry(
         group_id=5, cluster_id=CLUSTER_ON_OFF, target_endpoint_id=1
     )
+    # Both key spellings are emitted: chip/python reads authMode/deviceType,
+    # matter.js reads auth_mode/device_type.
     assert entry["authMode"] == ACL_AUTH_MODE_GROUP
+    assert entry["auth_mode"] == ACL_AUTH_MODE_GROUP
     assert entry["subjects"] == [5]
     assert entry["privilege"] == ACL_PRIVILEGE_OPERATE
     assert entry["targets"] == [
-        {"cluster": CLUSTER_ON_OFF, "endpoint": 1, "deviceType": None}
+        {
+            "cluster": CLUSTER_ON_OFF,
+            "endpoint": 1,
+            "deviceType": None,
+            "device_type": None,
+        }
     ]
 
 

--- a/tests/unit/test_bindings_parsing.py
+++ b/tests/unit/test_bindings_parsing.py
@@ -169,7 +169,7 @@ class TestBindingEntryKeyFormat:
         target = {"cluster": 6, "node": 3, "endpoint": 1, "group": None}
         assert _binding_entry(target, tag_keys=False) == {
             "cluster": 6,
-            "fabricIndex": 0,
+            "fabricIndex": 1,
             "node": 3,
             "endpoint": 1,
         }
@@ -183,7 +183,7 @@ class TestBindingEntryKeyFormat:
         target = {"cluster": 6, "node": 3, "endpoint": 1, "group": None}
         assert _binding_entry(target, tag_keys=True) == {
             "4": 6,
-            "254": 0,
+            "254": 1,
             "1": 3,
             "3": 1,
         }
@@ -195,7 +195,7 @@ class TestBindingEntryKeyFormat:
 
         # group=2, cluster=4, fabricIndex=254 (no node/endpoint for groupcast)
         target = {"cluster": 6, "node": None, "endpoint": None, "group": 7}
-        assert _binding_entry(target, tag_keys=True) == {"4": 6, "254": 0, "2": 7}
+        assert _binding_entry(target, tag_keys=True) == {"4": 6, "254": 1, "2": 7}
 
 
 class TestParseBindingValueTagKeys:

--- a/tests/unit/test_bindings_parsing.py
+++ b/tests/unit/test_bindings_parsing.py
@@ -196,3 +196,23 @@ class TestBindingEntryKeyFormat:
         # group=2, cluster=4, fabricIndex=254 (no node/endpoint for groupcast)
         target = {"cluster": 6, "node": None, "endpoint": None, "group": 7}
         assert _binding_entry(target, tag_keys=True) == {"4": 6, "254": 0, "2": 7}
+
+
+class TestParseBindingValueTagKeys:
+    """matter.js returns Binding entries keyed by numeric TLV tags."""
+
+    def test_parse_groupcast_binding_tag_keys(self):
+        # cluster=4 -> 6 (On/Off), group=2 -> 7
+        result = _parse_binding_value(1, 1, [{"4": 6, "2": 7, "254": 1}])
+        assert len(result) == 1
+        assert result[0].cluster_id == 6
+        assert result[0].target_group_id == 7
+        assert result[0].target_node_id is None
+
+    def test_parse_unicast_binding_tag_keys(self):
+        # cluster=4 -> 6, node=1 -> 3, endpoint=3 -> 1
+        result = _parse_binding_value(1, 1, [{"4": 6, "1": 3, "3": 1, "254": 1}])
+        assert len(result) == 1
+        assert result[0].cluster_id == 6
+        assert result[0].target_node_id == 3
+        assert result[0].target_endpoint_id == 1

--- a/tests/unit/test_bindings_parsing.py
+++ b/tests/unit/test_bindings_parsing.py
@@ -156,3 +156,43 @@ class TestParseBindingValueNoneCluster:
         assert result[0].cluster_id is None
         assert result[0].target_group_id == 100
         assert result[0].target_node_id is None
+
+
+class TestBindingEntryKeyFormat:
+    """Tests for _binding_entry camelCase vs numeric TLV tag key rendering."""
+
+    def test_unicast_entry_camelcase(self):
+        from custom_components.matter_binding_helper.matter.bindings import (
+            _binding_entry,
+        )
+
+        target = {"cluster": 6, "node": 3, "endpoint": 1, "group": None}
+        assert _binding_entry(target, tag_keys=False) == {
+            "cluster": 6,
+            "fabricIndex": 0,
+            "node": 3,
+            "endpoint": 1,
+        }
+
+    def test_unicast_entry_tag_keys(self):
+        from custom_components.matter_binding_helper.matter.bindings import (
+            _binding_entry,
+        )
+
+        # node=1, endpoint=3, cluster=4, fabricIndex=254
+        target = {"cluster": 6, "node": 3, "endpoint": 1, "group": None}
+        assert _binding_entry(target, tag_keys=True) == {
+            "4": 6,
+            "254": 0,
+            "1": 3,
+            "3": 1,
+        }
+
+    def test_groupcast_entry_tag_keys(self):
+        from custom_components.matter_binding_helper.matter.bindings import (
+            _binding_entry,
+        )
+
+        # group=2, cluster=4, fabricIndex=254 (no node/endpoint for groupcast)
+        target = {"cluster": 6, "node": None, "endpoint": None, "group": 7}
+        assert _binding_entry(target, tag_keys=True) == {"4": 6, "254": 0, "2": 7}

--- a/tests/unit/test_group_keys.py
+++ b/tests/unit/test_group_keys.py
@@ -65,6 +65,12 @@ def test_merge_updates_key_set_for_existing_group():
     assert result == [{"groupId": 5, "groupKeySetID": 0x200, "fabricIndex": 1}]
 
 
+def test_merge_emits_tag_keys_when_requested():
+    """matter.js only persists numeric TLV tag keys on the list write."""
+    result = merge_group_key_map(None, group_id=5, key_set_id=0x100, tag_keys=True)
+    assert result == [{"1": 5, "2": 0x100, "254": 1}]
+
+
 def test_merge_uses_supplied_fabric_index():
     """The accessing fabric index is honoured on every written entry."""
     existing = [{"groupId": 1, "groupKeySetID": 0x100, "fabricIndex": 2}]

--- a/tests/unit/test_group_keys.py
+++ b/tests/unit/test_group_keys.py
@@ -6,8 +6,18 @@ tests, since chip.clusters is only available in the real runtime.
 """
 
 from custom_components.matter_binding_helper.matter.group_keys import (
+    _group_key_map_has,
     merge_group_key_map,
 )
+
+
+def test_group_key_map_has_detects_mapping():
+    entries = [{"groupId": 5, "groupKeySetID": 0x100, "fabricIndex": 1}]
+    assert _group_key_map_has(entries, 5, 0x100) is True
+    assert _group_key_map_has(entries, 5, 0x200) is False  # wrong keyset
+    assert _group_key_map_has(entries, 9, 0x100) is False  # wrong group
+    assert _group_key_map_has(None, 5, 0x100) is False
+    assert _group_key_map_has([{"foo": "bar"}], 5, 0x100) is False
 
 
 def test_merge_into_empty_map():

--- a/tests/unit/test_group_keys.py
+++ b/tests/unit/test_group_keys.py
@@ -7,8 +7,27 @@ tests, since chip.clusters is only available in the real runtime.
 
 from custom_components.matter_binding_helper.matter.group_keys import (
     _group_key_map_has,
+    _unwrap_attr_list,
     merge_group_key_map,
 )
+
+
+def test_unwrap_attr_list_handles_path_wrapped_and_bare():
+    path = "0/63/0"
+    # read_attribute may wrap the value as {path: value} ...
+    assert _unwrap_attr_list({path: [{"1": 1}]}, path) == [{"1": 1}]
+    # ... or return the bare list ...
+    assert _unwrap_attr_list([{"1": 1}], path) == [{"1": 1}]
+    # ... or nothing usable.
+    assert _unwrap_attr_list(None, path) == []
+    assert _unwrap_attr_list({path: []}, path) == []
+
+
+def test_group_key_map_has_with_tag_keyed_entries():
+    """Device readback uses numeric TLV tag keys, not camelCase."""
+    readback = [{"1": 1, "2": 256, "254": 1}]  # groupId=1, keySetID=256, fabric=1
+    assert _group_key_map_has(readback, 1, 256) is True
+    assert _group_key_map_has(readback, 1, 999) is False
 
 
 def test_group_key_map_has_detects_mapping():


### PR DESCRIPTION
FIxes #307 

## Summary

Makes the full real-device groupcast flow — group key → `AddGroup` → binding → group-auth ACL → teardown — work end-to-end against **both** Matter server backends. The `e2e (matterjs)` job is now green for the first time.

Follow-up to #298 (the python/matter.js test matrix), which merged with `e2e (matterjs)` red. Every fix here was confirmed against matter.js 1.0's own source, not guessed.

## The matter.js 1.0 incompatibilities, and the fixes

1. **Fabric-scoped list-of-struct writes need numeric TLV tag keys.** matter.js's `convertWebSocketTagBasedToMatter` does `parseInt(key)`; camelCase keys fall through unmapped and the entry is silently dropped (no error). python-matter-server accepts camelCase. → `GroupKeyMap` and `Binding` writes now write camelCase first, read back to verify, and retry with tag keys (`1`/`2`/`254` …) on a miss.
2. **`fabricIndex: 0` → `CONSTRAINT_ERROR (135)`.** chip coerces a `0` to the accessing fabric; matter.js writes it literally and rs-matter rejects it. → Read `OperationalCredentials.CurrentFabricIndex` and write the real index (`GroupKeyMap`, `Binding`, delete-binding rewrite).
3. **Binding read returned tag-keyed entries** that `_parse_binding_value` ignored → binding looked absent. Now parses tag keys (and unwraps the `{path: value}` wrapper).
4. **`set_acl_entry` key convention differs:** matter.js reads snake_case (`auth_mode`, target `device_type`), chip reads camelCase. Sending only camelCase made matter.js build a bogus `device_type` that collided with `endpoint` → `CONSTRAINT_ERROR`. → Emit **both** spellings (each server ignores the key it doesn't know; chip's `dataclass_from_dict` is non-strict).
5. **matter-server cache lag.** Attributes are served from a subscription cache that lags fresh fabric-scoped writes. Verification read once immediately → false-negatives (this also caused a transient python regression: an aborted provision skipped the member ACL). → Provisioning verification and the e2e assertions now **poll**, and `provision_group_key` verification is **non-fatal** (proceed if unconfirmed).

## Diagnostics added (durable)

- e2e enables DEBUG logging for the integration and dumps its provisioning log lines on teardown (printed by the workflow). This is what pinpointed the `fabricIndex` `CONSTRAINT_ERROR`.
- A focused `test_add_to_group_persists_group_key` isolates group-key write persistence on both backends.

## Test results

```
e2e (python):   test_groupcast_binding_provisions_real_devices  PASSED
                test_add_to_group_persists_group_key            PASSED
e2e (matterjs): test_groupcast_binding_provisions_real_devices  PASSED
                test_add_to_group_persists_group_key            PASSED
```

- [x] 228 unit tests pass; `ruff check`/`format` clean
- [x] Full e2e matrix green on both backends (verified via dispatch on this branch)