### PR TITLE
refactor(client): route device I/O through the MatterClientProtocol seam (PR 1/4)

### DIFF
--- a/custom_components/matter_binding_helper/matter/acl.py
+++ b/custom_components/matter_binding_helper/matter/acl.py
@@ -19,7 +19,7 @@ from ..const import (
     CLUSTER_ACCESS_CONTROL,
     EVENT_ACL_PROGRESS,
 )
-from .client import get_raw_matter_client
+from .client import get_client
 from .demo import get_demo_acl, is_demo_mode, set_demo_acl
 from .models import (
     ACLEntry,
@@ -163,7 +163,7 @@ async def get_acl(hass: HomeAssistant, node_id: int) -> list[ACLEntry]:
         _LOGGER.debug("Demo mode enabled, returning demo ACL for node %s", node_id)
         return get_demo_acl(node_id)
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         _LOGGER.warning("get_acl: Matter client not available")
         return []
@@ -599,7 +599,7 @@ async def write_acl(
             acl_entries_count=len(acl_entries),
         )
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         return ACLProvisioningResult(
             success=False,
@@ -631,7 +631,7 @@ async def write_acl(
 
         # Use the dedicated SET_ACL_ENTRY API for ACL writes
         # This is more reliable than generic write_attribute
-        result = await client.send_command(
+        result = await client.send_raw_command(
             "set_acl_entry",
             node_id=node_id,
             entry=acl_entries,

--- a/custom_components/matter_binding_helper/matter/bindings.py
+++ b/custom_components/matter_binding_helper/matter/bindings.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 
 from ..const import CLUSTER_BINDING
 from .acl import provision_acl_for_binding, remove_acl_entry
-from .client import get_raw_matter_client
+from .client import get_client
 from .group_keys import _accessing_fabric_index
 from .groups import provision_group_for_binding, teardown_group_for_binding
 from .demo import (
@@ -46,7 +46,7 @@ async def get_bindings(
         )
         return get_demo_bindings(node_id, endpoint_id)
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         _LOGGER.warning("get_bindings: Matter client not available")
         return []
@@ -368,7 +368,7 @@ async def verify_bindings(
             bindings_found=len(cached),
         )
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         return BindingVerificationResult(
             success=False,
@@ -519,7 +519,7 @@ async def create_binding(
             bindings_found=len(cached),
         )
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         _LOGGER.error("create_binding: Matter client not available")
         return BindingVerificationResult(
@@ -812,7 +812,7 @@ async def delete_binding(
             bindings_found=len(cached),
         )
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         return BindingVerificationResult(
             success=False,

--- a/custom_components/matter_binding_helper/matter/client.py
+++ b/custom_components/matter_binding_helper/matter/client.py
@@ -71,6 +71,11 @@ class MatterClientProtocol(ABC):
         """Send a device command to a node."""
         ...
 
+    @abstractmethod
+    async def send_raw_command(self, command: str, **kwargs: Any) -> Any:
+        """Send a high-level matter-server WS command by name (e.g. set_acl_entry)."""
+        ...
+
 
 class RealMatterClient(MatterClientProtocol):
     """Wraps the actual python-matter-server client."""
@@ -137,6 +142,10 @@ class RealMatterClient(MatterClientProtocol):
             endpoint_id=endpoint_id,
             command=command,
         )
+
+    async def send_raw_command(self, command: str, **kwargs: Any) -> Any:
+        """Send a high-level matter-server WS command by name (e.g. set_acl_entry)."""
+        return await self._client.send_command(command, **kwargs)
 
 
 def get_raw_matter_client(hass: HomeAssistant) -> "RealMatterServerClient | None":

--- a/custom_components/matter_binding_helper/matter/group_keys.py
+++ b/custom_components/matter_binding_helper/matter/group_keys.py
@@ -29,7 +29,7 @@ from ..const import (
     GROUP_EPOCH_START_TIME,
     GROUP_KEY_SECURITY_POLICY_TRUST_FIRST,
 )
-from .client import get_raw_matter_client
+from .client import get_client
 from .demo import is_demo_mode
 from .models import GroupOperationResult
 
@@ -208,7 +208,7 @@ async def provision_group_key(
         )
         return GroupOperationResult(success=True, message="Demo mode: group key set")
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         return GroupOperationResult(
             success=False,

--- a/custom_components/matter_binding_helper/matter/groups.py
+++ b/custom_components/matter_binding_helper/matter/groups.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant
 
 from ..const import CLUSTER_GROUPS, EVENT_GROUP_PROGRESS
 from .acl import provision_group_acl, remove_group_acl
-from .client import get_raw_matter_client
+from .client import get_client
 from .demo import (
     add_demo_group_member,
     create_demo_group,
@@ -172,7 +172,7 @@ async def delete_group(hass: HomeAssistant, group_id: int) -> GroupOperationResu
             error_code=GROUP_NOT_FOUND_CODE,
         )
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if client:
         for member in record.members:
             try:
@@ -223,7 +223,7 @@ async def add_to_group(
             error_code=GROUP_NOT_FOUND_CODE,
         )
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         return _client_unavailable()
 
@@ -292,7 +292,7 @@ async def remove_from_group(
             error_code=GROUP_NOT_FOUND_CODE,
         )
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         return _client_unavailable()
 

--- a/custom_components/matter_binding_helper/matter/nodes.py
+++ b/custom_components/matter_binding_helper/matter/nodes.py
@@ -14,7 +14,7 @@ from ..const import (
     CLUSTER_BINDING,
     CLUSTER_DESCRIPTOR,
 )
-from .client import get_raw_matter_client
+from .client import get_client
 from .demo import get_demo_nodes, is_demo_mode
 from .ha_registry import get_ha_device_info
 
@@ -31,7 +31,7 @@ async def get_nodes(hass: HomeAssistant) -> list[dict[str, Any]]:
         _LOGGER.debug("Demo mode enabled, returning demo nodes")
         return get_demo_nodes()
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         _LOGGER.error("Matter client not available")
         return []

--- a/custom_components/matter_binding_helper/matter/proprietary.py
+++ b/custom_components/matter_binding_helper/matter/proprietary.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from .client import get_raw_matter_client
+from .client import get_client
 from .demo import is_demo_mode
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ async def get_proprietary_attributes(
     if is_demo_mode(hass):
         return results
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         _LOGGER.warning("get_proprietary_attributes: Matter client not available")
         return results

--- a/custom_components/matter_binding_helper/matter/thermostat.py
+++ b/custom_components/matter_binding_helper/matter/thermostat.py
@@ -12,7 +12,7 @@ from ..const import (
     CLUSTER_THERMOSTAT,
     CMD_GET_WEEKLY_SCHEDULE,
 )
-from .client import get_raw_matter_client
+from .client import get_client
 from .demo import is_demo_mode
 from .models import ScheduleTransition, WeeklySchedule
 
@@ -86,7 +86,7 @@ def get_cluster_accepted_commands(
     Returns:
         List of command IDs the cluster accepts, or None if not available
     """
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         return None
 
@@ -221,7 +221,7 @@ async def get_thermostat_schedule(
             ],
         )
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         _LOGGER.error("get_thermostat_schedule: Matter client not available")
         return None
@@ -327,7 +327,7 @@ async def set_thermostat_schedule(
         )
         return True
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         _LOGGER.error("set_thermostat_schedule: Matter client not available")
         return False
@@ -418,7 +418,7 @@ async def clear_thermostat_schedule(
         )
         return True
 
-    client = get_raw_matter_client(hass)
+    client = get_client(hass)
     if not client:
         _LOGGER.error("clear_thermostat_schedule: Matter client not available")
         return False

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -140,7 +140,7 @@ async def test_real_delete_missing_group(hass):
 @pytest.mark.asyncio
 async def test_real_delete_empty_group(hass):
     await create_group(hass, 10, "Hallway")
-    with patch.object(groups, "get_raw_matter_client", return_value=None):
+    with patch.object(groups, "get_client", return_value=None):
         result = await delete_group(hass, 10)
     assert result.success is True
     assert await get_groups(hass) == []
@@ -156,7 +156,7 @@ async def test_real_add_to_missing_group(hass):
 @pytest.mark.asyncio
 async def test_real_add_client_unavailable(hass):
     await create_group(hass, 10, "Hallway")
-    with patch.object(groups, "get_raw_matter_client", return_value=None):
+    with patch.object(groups, "get_client", return_value=None):
         result = await add_to_group(hass, 10, 5, 1)
     assert result.success is False
     assert result.error_code == "client_unavailable"
@@ -165,7 +165,7 @@ async def test_real_add_client_unavailable(hass):
 @pytest.mark.asyncio
 async def test_real_remove_client_unavailable(hass):
     await create_group(hass, 10, "Hallway")
-    with patch.object(groups, "get_raw_matter_client", return_value=None):
+    with patch.object(groups, "get_client", return_value=None):
         result = await remove_from_group(hass, 10, 5, 1)
     assert result.success is False
     assert result.error_code == "client_unavailable"


### PR DESCRIPTION
First of the #61 series — turning the Matter client into a clean, injectable seam so we can (a) support non-default/dev server endpoints, (b) centralize the python↔matter.js wire-format handling, and (c) unit-test device logic without a real device.

## What this PR does (PR 1: the seam, no behavior change)

The integration reached into HA's Matter client via `get_raw_matter_client` in **16 device-I/O call sites** across `bindings`, `groups`, `group_keys`, `acl`, `thermostat`, `nodes`, `proprietary`. That's why the python/matter.js wire-format fixes (#308) had to be smeared across all of them, and why every behavior check needed a 9-minute real-device e2e cycle.

This routes them all through `get_client() -> MatterClientProtocol`:
- Adds `send_raw_command()` to the protocol for high-level WS commands (`set_acl_entry` — the one call that isn't plain attribute/device I/O).
- Migrates the device-I/O modules to `get_client`.

**No behavior change:** every device-I/O function already guards demo mode before acquiring the client, and the wrapper exposes the same surface (`get_nodes` / `read_attribute` / `write_attribute` / `send_device_command` / `send_raw_command`). `api.py` + `telemetry.py` stay on the `get_matter_client` alias (read-only `get_nodes`) — migrated later.

## Why (the plan)

- **PR 1 (this):** establish the seam / chokepoint.
- **PR 2:** move the wire-format logic (tag-keys↔camelCase, real `fabricIndex`, `{path:value}` unwrap, cache-lag poll, write-status) out of the modules and into the client layer.
- **PR 3 (#61):** configurable client source — use HA's Matter integration (default) or connect to a server URL (dev/non-default/fallback).
- **PR 4:** a `FakeMatterClient` simulating both backends, turning this session's bugs into millisecond regression tests.

## Test plan

- [x] 228 unit tests pass (incl. updated client-unavailable mocks)
- [x] `ruff check`/`format` clean
- [ ] Full matrix (integration + e2e, both backends) green on CI — this is the behavior-preservation safety net