### PR TITLE
refactor(wire): centralize fabric-scoped write mechanism (PR 2/4)

### DIFF
--- a/custom_components/matter_binding_helper/matter/bindings.py
+++ b/custom_components/matter_binding_helper/matter/bindings.py
@@ -11,7 +11,6 @@ from homeassistant.core import HomeAssistant
 from ..const import CLUSTER_BINDING
 from .acl import provision_acl_for_binding, remove_acl_entry
 from .client import get_client
-from .group_keys import _accessing_fabric_index
 from .groups import provision_group_for_binding, teardown_group_for_binding
 from .demo import (
     add_demo_binding,
@@ -26,6 +25,10 @@ from .utils import (
     get_user_friendly_error,
     parse_error_type,
 )
+from .wire import write_fabric_scoped_list
+
+# Binding TargetStruct field name -> TLV tag.
+BINDING_TAGS = {"node": 1, "group": 2, "endpoint": 3, "cluster": 4}
 
 if TYPE_CHECKING:
     from matter_server.client import MatterClient
@@ -432,40 +435,6 @@ async def verify_bindings(
         )
 
 
-def _binding_entry(
-    target: dict[str, Any], tag_keys: bool, fabric_index: int = 1
-) -> dict[str, Any]:
-    """Render one Binding TargetStruct entry in camelCase or numeric TLV tag keys.
-
-    matter.js only persists tag-keyed list-of-struct entries (Binding tags:
-    node=1, group=2, endpoint=3, cluster=4, fabricIndex=254); python-matter-server
-    accepts either. The fabric index must be the real accessing fabric: chip
-    coerces a 0, but matter.js writes it literally and rs-matter rejects
-    fabricIndex 0 with CONSTRAINT_ERROR.
-    """
-    cluster = target["cluster"]
-    node = target.get("node")
-    endpoint = target.get("endpoint")
-    group = target.get("group")
-    if tag_keys:
-        entry: dict[str, Any] = {"4": cluster, "254": fabric_index}
-        if node is not None:
-            entry["1"] = node
-        if group is not None:
-            entry["2"] = group
-        if endpoint is not None:
-            entry["3"] = endpoint
-        return entry
-    entry = {"cluster": cluster, "fabricIndex": fabric_index}
-    if node is not None:
-        entry["node"] = node
-    if endpoint is not None:
-        entry["endpoint"] = endpoint
-    if group is not None:
-        entry["group"] = group
-    return entry
-
-
 async def create_binding(
     hass: HomeAssistant,
     source_node_id: int,
@@ -578,55 +547,38 @@ async def create_binding(
             }
         )
 
-        # Write the binding attribute. Like GroupKeyMap, Binding is a fabric-scoped
-        # list-of-struct: python-matter-server accepts camelCase field names, but
-        # matter.js silently drops entries it can't map and only persists numeric
-        # TLV tag keys. Write camelCase first, read back, and retry with tag keys
-        # on a miss so both backends work.
+        # Write the binding attribute. Binding is a fabric-scoped list-of-struct;
+        # wire owns the camelCase/tag-key + fabricIndex + cache-lag handling.
+        # Verify through get_bindings (node cache) — the same source the rest of
+        # the integration reads.
         attribute_path = f"{source_endpoint_id}/{CLUSTER_BINDING}/0"
         _LOGGER.info("create_binding: Writing to attribute path: %s", attribute_path)
 
-        # Binding is fabric-scoped: rs-matter rejects fabricIndex 0 with
-        # CONSTRAINT_ERROR when the controller (matter.js) writes it literally.
-        fabric_index = await _accessing_fabric_index(client, source_node_id)
-        for tag_keys in (False, True):
-            binding_list = [_binding_entry(t, tag_keys, fabric_index) for t in targets]
-            _LOGGER.debug(
-                "create_binding: writing binding list (%s keys): %s",
-                "tag" if tag_keys else "name",
-                binding_list,
-            )
-            result = await client.write_attribute(
-                node_id=source_node_id,
-                attribute_path=attribute_path,
-                value=binding_list,
-            )
-            _LOGGER.info("create_binding: write_attribute result: %s", result)
+        async def _read_bindings() -> list[BindingEntry]:
+            return await get_bindings(hass, source_node_id, source_endpoint_id)
 
-            # Poll the readback: matter-server's attribute cache lags a fresh
-            # fabric-scoped write, so a single immediate read can false-negative a
-            # write that succeeded.
-            persisted = False
-            for _ in range(5):
-                read_back = await get_bindings(hass, source_node_id, source_endpoint_id)
-                if any(
-                    binding_matches(
-                        b,
-                        target_node_id,
-                        target_endpoint_id,
-                        target_group_id,
-                        cluster_id,
-                    )
-                    for b in read_back
-                ):
-                    persisted = True
-                    break
-                await asyncio.sleep(1.5)
-            if persisted:
-                if tag_keys:
-                    _LOGGER.info("create_binding: binding accepted using tag keys")
-                break
-        else:
+        def _has_new_binding(read_back: list[BindingEntry]) -> bool:
+            return any(
+                binding_matches(
+                    b,
+                    target_node_id,
+                    target_endpoint_id,
+                    target_group_id,
+                    cluster_id,
+                )
+                for b in read_back
+            )
+
+        persisted, _ = await write_fabric_scoped_list(
+            client,
+            source_node_id,
+            attribute_path,
+            targets,
+            BINDING_TAGS,
+            _has_new_binding,
+            read_entries=_read_bindings,
+        )
+        if not persisted:
             _LOGGER.warning(
                 "create_binding: binding did not persist on node %s after "
                 "camelCase and tag-key writes",
@@ -740,7 +692,7 @@ async def create_binding(
             success=True,
             verified=False,  # Not verified because verify=False
             message="Binding written (verification skipped)",
-            bindings_found=len(binding_list),
+            bindings_found=len(targets),
         )
 
     except Exception as err:
@@ -873,12 +825,11 @@ async def delete_binding(
                 bindings_found=len(current_bindings),
             )
 
-        # Rewrite the remaining bindings. Same fabric-scoped/tag-key concerns as
-        # create_binding: use the real accessing fabric index, and retry with tag
-        # keys if matter.js drops the camelCase write.
+        # Rewrite the remaining bindings through wire (same fabric-scoped/tag-key
+        # mechanism as create_binding), verifying the list shrank to the expected
+        # length via get_bindings.
         attribute_path = f"{source_endpoint_id}/{CLUSTER_BINDING}/0"
         _LOGGER.info("delete_binding: Writing to attribute path: %s", attribute_path)
-        fabric_index = await _accessing_fabric_index(client, source_node_id)
         targets = [
             {
                 "cluster": b.cluster_id,
@@ -889,18 +840,18 @@ async def delete_binding(
             for b in filtered_bindings
         ]
 
-        result = None
-        for tag_keys in (False, True):
-            binding_list = [_binding_entry(t, tag_keys, fabric_index) for t in targets]
-            result = await client.write_attribute(
-                node_id=source_node_id,
-                attribute_path=attribute_path,
-                value=binding_list,
-            )
-            read_back = await get_bindings(hass, source_node_id, source_endpoint_id)
-            if len(read_back) == len(filtered_bindings):
-                break
-        _LOGGER.info("delete_binding: write_attribute result: %s", result)
+        async def _read_bindings() -> list[BindingEntry]:
+            return await get_bindings(hass, source_node_id, source_endpoint_id)
+
+        await write_fabric_scoped_list(
+            client,
+            source_node_id,
+            attribute_path,
+            targets,
+            BINDING_TAGS,
+            lambda read_back: len(read_back) == len(filtered_bindings),
+            read_entries=_read_bindings,
+        )
 
         # Remove ACL entry from target device if requested (for unicast bindings)
         if (
@@ -1017,7 +968,7 @@ async def delete_binding(
             success=True,
             verified=False,  # Not verified because verify=False
             message="Binding deletion written (verification skipped)",
-            bindings_found=len(binding_list),
+            bindings_found=len(targets),
         )
 
     except Exception as err:

--- a/custom_components/matter_binding_helper/matter/group_keys.py
+++ b/custom_components/matter_binding_helper/matter/group_keys.py
@@ -7,100 +7,34 @@ can encrypt/decrypt groupcast traffic. These are prerequisites for
 Matter spec) reject ``AddGroup`` unless the fabric already holds group key
 material for the group.
 
-Both operations go through the generic matter-server primitives:
-- ``KeySetWrite`` is a command → ``send_device_command`` with a chip struct.
-- ``GroupKeyMap`` is a list-of-struct attribute → ``write_attribute`` with plain
-  dicts (the same approach bindings.py uses for the Binding attribute).
+``KeySetWrite`` is a command (``send_device_command`` with a chip struct); the
+``GroupKeyMap`` write goes through :func:`matter.wire.write_fabric_scoped_list`,
+which owns the camelCase/tag-key + fabricIndex + cache-lag mechanism.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 
 from ..const import (
-    ATTR_CURRENT_FABRIC_INDEX,
     ATTR_GROUP_KEY_MAP,
     CLUSTER_GROUP_KEY_MANAGEMENT,
-    CLUSTER_OPERATIONAL_CREDENTIALS,
     GROUP_EPOCH_START_TIME,
     GROUP_KEY_SECURITY_POLICY_TRUST_FIRST,
 )
 from .client import get_client
 from .demo import is_demo_mode
 from .models import GroupOperationResult
+from .wire import struct_field, unwrap_attr_list, write_fabric_scoped_list
 
 _LOGGER = logging.getLogger(__name__)
 
 GROUP_KEY_MAP_PATH = f"0/{CLUSTER_GROUP_KEY_MANAGEMENT}/{ATTR_GROUP_KEY_MAP}"
-CURRENT_FABRIC_INDEX_PATH = (
-    f"0/{CLUSTER_OPERATIONAL_CREDENTIALS}/{ATTR_CURRENT_FABRIC_INDEX}"
-)
-
-
-async def _accessing_fabric_index(client: Any, node_id: int) -> int:
-    """Read the device's CurrentFabricIndex (the accessing fabric).
-
-    Fabric-scoped writes must carry the real fabric index. python-matter-server
-    coerces a 0 to the accessing fabric, but matter.js writes it literally, so a
-    hardcoded 0 lands the GroupKeyMap on fabric 0 and the device rejects AddGroup
-    with UNSUPPORTED_ACCESS. Fabric indices are 1-based; fall back to 1.
-    """
-    try:
-        value = await client.read_attribute(
-            node_id=node_id, attribute_path=CURRENT_FABRIC_INDEX_PATH
-        )
-        # read_attribute may wrap the scalar as {"0/62/5": value}.
-        if isinstance(value, dict):
-            value = value.get(CURRENT_FABRIC_INDEX_PATH, value)
-        index = int(value)
-        # Log the raw value: a 0 here means the controller is reaching the device
-        # without a promoted operational fabric, which makes every fabric-scoped
-        # write/command (KeySetWrite, GroupKeyMap, AddGroup) fail UNSUPPORTED_ACCESS.
-        _LOGGER.info(
-            "provision_group_key: node %s reports CurrentFabricIndex=%s",
-            node_id,
-            index,
-        )
-        if index >= 1:
-            return index
-    except (ValueError, TypeError, AttributeError) as err:
-        _LOGGER.warning(
-            "Could not read CurrentFabricIndex for node %s (%s); assuming 1",
-            node_id,
-            err,
-        )
-    return 1
-
-
-def _entry_field(entry: Any, *keys: Any) -> Any:
-    """Read a field from a GroupKeyMap entry (dict or chip struct)."""
-    if isinstance(entry, dict):
-        for k in keys:
-            if k in entry and entry[k] is not None:
-                return entry[k]
-    else:
-        for k in keys:
-            if isinstance(k, str) and hasattr(entry, k):
-                val = getattr(entry, k)
-                if val is not None:
-                    return val
-    return None
-
-
-def _unwrap_attr_list(value: Any, path: str) -> list[Any]:
-    """Normalize a read_attribute result to a bare list.
-
-    read_attribute may return the value directly or wrapped as
-    ``{"<endpoint>/<cluster>/<attr>": value}``. Unwrap so callers always see the
-    list of entries.
-    """
-    if isinstance(value, dict) and path in value:
-        value = value[path]
-    return value if isinstance(value, list) else []
+# GroupKeyMapStruct field name -> TLV tag.
+GROUP_KEY_MAP_TAGS = {"groupId": 1, "groupKeySetID": 2}
 
 
 def _group_key_map_has(
@@ -108,8 +42,8 @@ def _group_key_map_has(
 ) -> bool:
     """True if the GroupKeyMap contains the group_id -> key_set_id mapping."""
     for entry in existing or []:
-        gid = _entry_field(entry, "groupId", "1", 1)
-        ksid = _entry_field(entry, "groupKeySetID", "2", 2)
+        gid = struct_field(entry, "groupId", 1)
+        ksid = struct_field(entry, "groupKeySetID", 2)
         if gid is None or ksid is None:
             continue
         if int(gid) == group_id and int(ksid) == key_set_id:
@@ -117,55 +51,32 @@ def _group_key_map_has(
     return False
 
 
-def _group_key_entry(
-    group_id: int, key_set_id: int, fabric_index: int, tag_keys: bool
-) -> dict[str, int]:
-    """One GroupKeyMap entry, keyed by either field name or numeric TLV tag.
-
-    python-matter-server accepts camelCase field names on write; matter.js
-    silently drops entries it cannot map and only persists numeric tag keys
-    (``1``=groupId, ``2``=groupKeySetID, ``254``=fabricIndex), which is also the
-    shape both servers return on read.
-    """
-    if tag_keys:
-        return {"1": group_id, "2": key_set_id, "254": fabric_index}
-    return {
-        "groupId": group_id,
-        "groupKeySetID": key_set_id,
-        "fabricIndex": fabric_index,
-    }
-
-
 def merge_group_key_map(
     existing: list[Any] | None,
     group_id: int,
     key_set_id: int,
-    fabric_index: int = 1,
-    tag_keys: bool = False,
 ) -> list[dict[str, int]]:
-    """Return the GroupKeyMap list with (group_id -> key_set_id) ensured present.
+    """Return the GroupKeyMap as logical entries with the mapping ensured present.
 
-    Pure read-modify-write helper. Preserves existing mappings, is idempotent
-    (no duplicate for the same group_id), and normalizes every entry to a plain
-    dict suitable for ``write_attribute``. ``fabric_index`` must be the accessing
-    fabric. ``tag_keys`` selects numeric TLV tag keys over camelCase field names
-    (see ``_group_key_entry``).
+    Pure read-modify-write helper: preserves existing mappings, is idempotent (no
+    duplicate for the same group_id), and returns plain ``{groupId, groupKeySetID}``
+    dicts. Encoding (key format + fabricIndex) is handled by ``wire``.
     """
     result: list[dict[str, int]] = []
     found = False
     for entry in existing or []:
-        gid = _entry_field(entry, "groupId", "1", 1)
-        ksid = _entry_field(entry, "groupKeySetID", "2", 2)
+        gid = struct_field(entry, "groupId", 1)
+        ksid = struct_field(entry, "groupKeySetID", 2)
         if gid is None or ksid is None:
             continue
         gid, ksid = int(gid), int(ksid)
         if gid == group_id:
             found = True
             ksid = key_set_id  # update to the desired key set
-        result.append(_group_key_entry(gid, ksid, fabric_index, tag_keys))
+        result.append({"groupId": gid, "groupKeySetID": ksid})
 
     if not found:
-        result.append(_group_key_entry(group_id, key_set_id, fabric_index, tag_keys))
+        result.append({"groupId": group_id, "groupKeySetID": key_set_id})
     return result
 
 
@@ -238,73 +149,39 @@ async def provision_group_key(
             command=_build_key_set_write_command(key_set_id, epoch_key),
         )
 
-        # 2. Map the group id to the key set in GroupKeyMap (read-modify-write),
-        #    scoped to the accessing fabric. We verify the write landed by reading
-        #    it back: matter.js silently drops a camelCase list-of-struct write
-        #    (no error, attribute stays empty), so on the first miss we retry with
-        #    numeric TLV tag keys — the shape both servers return on read.
-        fabric_index = await _accessing_fabric_index(client, node_id)
-        last_readback: Any = None
-        for tag_keys in (False, True):
-            existing = _unwrap_attr_list(
-                await client.read_attribute(
-                    node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
-                ),
-                GROUP_KEY_MAP_PATH,
+        # 2. Map the group id to the key set in GroupKeyMap (read-modify-write).
+        existing = unwrap_attr_list(
+            await client.read_attribute(
+                node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
+            ),
+            GROUP_KEY_MAP_PATH,
+        )
+        entries = merge_group_key_map(existing, group_id, key_set_id)
+        ok, last_readback = await write_fabric_scoped_list(
+            client,
+            node_id,
+            GROUP_KEY_MAP_PATH,
+            entries,
+            GROUP_KEY_MAP_TAGS,
+            lambda rb: _group_key_map_has(rb, group_id, key_set_id),
+        )
+        if ok:
+            return GroupOperationResult(
+                success=True,
+                message=f"Provisioned group key for group {group_id} on node {node_id}",
             )
-            updated = merge_group_key_map(
-                existing, group_id, key_set_id, fabric_index, tag_keys=tag_keys
-            )
-            await client.write_attribute(
-                node_id=node_id,
-                attribute_path=GROUP_KEY_MAP_PATH,
-                value=updated,
-            )
-            # matter-server serves attributes from a subscription cache that lags
-            # a fresh fabric-scoped write, so poll the readback before concluding
-            # the format was rejected (otherwise a slow cache false-negatives a
-            # write that actually succeeded).
-            found = False
-            for attempt in range(5):
-                last_readback = _unwrap_attr_list(
-                    await client.read_attribute(
-                        node_id=node_id, attribute_path=GROUP_KEY_MAP_PATH
-                    ),
-                    GROUP_KEY_MAP_PATH,
-                )
-                if _group_key_map_has(last_readback, group_id, key_set_id):
-                    found = True
-                    break
-                await asyncio.sleep(1.5)
-            if found:
-                _LOGGER.info(
-                    "provision_group_key: GroupKeyMap accepted on node %s using "
-                    "%s keys (group %s -> keyset %s, fabric %s)",
-                    node_id,
-                    "tag" if tag_keys else "name",
-                    group_id,
-                    key_set_id,
-                    fabric_index,
-                )
-                return GroupOperationResult(
-                    success=True,
-                    message=(
-                        f"Provisioned group key for group {group_id} on node {node_id}"
-                    ),
-                )
 
-        # 3. Could not confirm via readback. The write itself did not error and
-        #    the matter-server cache can lag indefinitely, so proceed optimistically
-        #    (as the original non-verifying code did) rather than aborting the whole
-        #    groupcast flow — verification is best-effort, not a gate.
+        # Could not confirm via readback. The write itself did not error and the
+        # matter-server cache can lag indefinitely, so proceed optimistically (as
+        # the original non-verifying code did) rather than aborting the whole
+        # groupcast flow — verification is best-effort, not a gate.
         _LOGGER.warning(
             "provision_group_key: could not confirm GroupKeyMap on node %s for "
-            "group %s -> keyset %s (fabric %s) after name+tag writes; readback=%s. "
-            "Proceeding; AddGroup will surface a real rejection if the key is absent.",
+            "group %s -> keyset %s; readback=%s. Proceeding; AddGroup will surface "
+            "a real rejection if the key is absent.",
             node_id,
             group_id,
             key_set_id,
-            fabric_index,
             last_readback,
         )
         return GroupOperationResult(

--- a/custom_components/matter_binding_helper/matter/wire.py
+++ b/custom_components/matter_binding_helper/matter/wire.py
@@ -1,0 +1,160 @@
+"""Wire-format helpers for fabric-scoped Matter list-of-struct attributes.
+
+matter.js and python-matter-server disagree on the JSON shape of fabric-scoped
+list-of-struct attribute writes (GroupKeyMap, Binding):
+
+- python-matter-server (chip) accepts camelCase field names and coerces a 0
+  ``fabricIndex`` to the accessing fabric.
+- matter.js requires numeric TLV tag keys and writes ``fabricIndex`` literally,
+  so rs-matter rejects a 0 with CONSTRAINT_ERROR.
+
+On top of that, matter-server serves attributes from a subscription cache that
+lags a fresh fabric-scoped write.
+
+These helpers own that mechanism so callers stay declarative: provide the
+field→tag map and a verify predicate, and ``write_fabric_scoped_list`` resolves
+the accessing fabric, writes camelCase, polls the readback, and retries with tag
+keys on a miss. Everything here works against the ``MatterClientProtocol`` seam,
+so it is unit-testable with a fake client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable
+
+from ..const import ATTR_CURRENT_FABRIC_INDEX, CLUSTER_OPERATIONAL_CREDENTIALS
+
+_LOGGER = logging.getLogger(__name__)
+
+CURRENT_FABRIC_INDEX_PATH = (
+    f"0/{CLUSTER_OPERATIONAL_CREDENTIALS}/{ATTR_CURRENT_FABRIC_INDEX}"
+)
+# The FabricIndex field carries TLV tag 254 on every fabric-scoped struct.
+FABRIC_INDEX_TAG = 254
+FABRIC_INDEX_NAME = "fabricIndex"
+
+
+def unwrap_attr(value: Any, path: str) -> Any:
+    """Unwrap a read_attribute result that may be ``{"<path>": value}``."""
+    if isinstance(value, dict) and path in value:
+        return value[path]
+    return value
+
+
+def unwrap_attr_list(value: Any, path: str) -> list[Any]:
+    """Unwrap a read_attribute result to a bare list (empty if not a list)."""
+    value = unwrap_attr(value, path)
+    return value if isinstance(value, list) else []
+
+
+async def current_fabric_index(client: Any, node_id: int) -> int:
+    """Read the device's accessing fabric index (1-based; falls back to 1).
+
+    Fabric-scoped writes must carry this index: chip coerces a 0, but matter.js
+    writes it literally and the device rejects 0.
+    """
+    try:
+        value = unwrap_attr(
+            await client.read_attribute(
+                node_id=node_id, attribute_path=CURRENT_FABRIC_INDEX_PATH
+            ),
+            CURRENT_FABRIC_INDEX_PATH,
+        )
+        index = int(value)
+        if index >= 1:
+            return index
+    except (ValueError, TypeError, AttributeError) as err:
+        _LOGGER.warning(
+            "Could not read CurrentFabricIndex for node %s (%s); assuming 1",
+            node_id,
+            err,
+        )
+    return 1
+
+
+def encode_struct(
+    fields: dict[str, Any],
+    tag_map: dict[str, int],
+    fabric_index: int,
+    tag_keys: bool,
+) -> dict[str, Any]:
+    """Encode one struct as either camelCase or numeric TLV tag keys.
+
+    ``fields`` is name→value (None values are dropped); ``tag_map`` is name→tag.
+    The fabric index is always included (tag 254 / ``fabricIndex``).
+    """
+    result: dict[str, Any] = {}
+    for name, value in fields.items():
+        if value is None:
+            continue
+        result[str(tag_map[name]) if tag_keys else name] = value
+    fabric_key = str(FABRIC_INDEX_TAG) if tag_keys else FABRIC_INDEX_NAME
+    result[fabric_key] = fabric_index
+    return result
+
+
+def struct_field(entry: Any, name: str, tag: int) -> Any:
+    """Read a struct field from a readback entry, by name or numeric tag key."""
+    if isinstance(entry, dict):
+        for key in (name, str(tag), tag):
+            if key in entry and entry[key] is not None:
+                return entry[key]
+    else:
+        if hasattr(entry, name):
+            val = getattr(entry, name)
+            if val is not None:
+                return val
+    return None
+
+
+async def write_fabric_scoped_list(
+    client: Any,
+    node_id: int,
+    attribute_path: str,
+    entries: list[dict[str, Any]],
+    tag_map: dict[str, int],
+    verify: Callable[[list[Any]], bool],
+    *,
+    read_entries: Callable[[], Any] | None = None,
+    attempts: int = 5,
+    delay: float = 1.5,
+) -> tuple[bool, list[Any]]:
+    """Write a fabric-scoped list-of-struct, verifying it landed.
+
+    ``entries`` are logical name→value dicts (no fabricIndex — added here).
+    Writes camelCase first, polls the readback against ``verify`` (cache lag),
+    and retries with tag keys on a miss. Returns ``(ok, last_readback)``.
+
+    ``read_entries`` overrides how the readback is fetched (e.g. via a parsed
+    higher-level reader); it defaults to ``read_attribute`` on ``attribute_path``.
+    ``verify`` runs on whatever ``read_entries`` returns.
+    """
+
+    async def _default_read() -> list[Any]:
+        return unwrap_attr_list(
+            await client.read_attribute(node_id=node_id, attribute_path=attribute_path),
+            attribute_path,
+        )
+
+    read = read_entries or _default_read
+    fabric_index = await current_fabric_index(client, node_id)
+    last_readback: list[Any] = []
+    for tag_keys in (False, True):
+        payload = [encode_struct(e, tag_map, fabric_index, tag_keys) for e in entries]
+        await client.write_attribute(
+            node_id=node_id, attribute_path=attribute_path, value=payload
+        )
+        for _ in range(attempts):
+            last_readback = await read()
+            if verify(last_readback):
+                if tag_keys:
+                    _LOGGER.info(
+                        "write_fabric_scoped_list: %s accepted with tag keys on node %s",
+                        attribute_path,
+                        node_id,
+                    )
+                return True, last_readback
+            await asyncio.sleep(delay)
+    return False, last_readback

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ import pytest
 import pytest_asyncio
 import requests
 from testcontainers.core.container import DockerContainer
-from testcontainers.core.waiting_utils import wait_for_logs
 from websockets.asyncio.client import connect
 
 
@@ -300,7 +299,7 @@ class HABootstrapper:
                 # Wait for commissioning result (can take a while)
                 msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=120))
                 if msg.get("success"):
-                    print(f"[testcontainers] Device commissioned successfully!")
+                    print("[testcontainers] Device commissioned successfully!")
                     return True
                 else:
                     print(f"Commissioning failed: {msg}")

--- a/tests/unit/test_bindings_parsing.py
+++ b/tests/unit/test_bindings_parsing.py
@@ -158,44 +158,36 @@ class TestParseBindingValueNoneCluster:
         assert result[0].target_node_id is None
 
 
-class TestBindingEntryKeyFormat:
-    """Tests for _binding_entry camelCase vs numeric TLV tag key rendering."""
-
-    def test_unicast_entry_camelcase(self):
-        from custom_components.matter_binding_helper.matter.bindings import (
-            _binding_entry,
-        )
-
-        target = {"cluster": 6, "node": 3, "endpoint": 1, "group": None}
-        assert _binding_entry(target, tag_keys=False) == {
-            "cluster": 6,
-            "fabricIndex": 1,
-            "node": 3,
-            "endpoint": 1,
-        }
+class TestBindingTagMap:
+    """The Binding field->tag map encodes correctly via wire.encode_struct."""
 
     def test_unicast_entry_tag_keys(self):
         from custom_components.matter_binding_helper.matter.bindings import (
-            _binding_entry,
+            BINDING_TAGS,
         )
+        from custom_components.matter_binding_helper.matter.wire import encode_struct
 
-        # node=1, endpoint=3, cluster=4, fabricIndex=254
         target = {"cluster": 6, "node": 3, "endpoint": 1, "group": None}
-        assert _binding_entry(target, tag_keys=True) == {
+        # node=1, endpoint=3, cluster=4, fabricIndex=254; group dropped (None)
+        assert encode_struct(target, BINDING_TAGS, 1, tag_keys=True) == {
             "4": 6,
-            "254": 1,
             "1": 3,
             "3": 1,
+            "254": 1,
         }
 
-    def test_groupcast_entry_tag_keys(self):
+    def test_groupcast_entry_camelcase(self):
         from custom_components.matter_binding_helper.matter.bindings import (
-            _binding_entry,
+            BINDING_TAGS,
         )
+        from custom_components.matter_binding_helper.matter.wire import encode_struct
 
-        # group=2, cluster=4, fabricIndex=254 (no node/endpoint for groupcast)
         target = {"cluster": 6, "node": None, "endpoint": None, "group": 7}
-        assert _binding_entry(target, tag_keys=True) == {"4": 6, "254": 1, "2": 7}
+        assert encode_struct(target, BINDING_TAGS, 1, tag_keys=False) == {
+            "cluster": 6,
+            "group": 7,
+            "fabricIndex": 1,
+        }
 
 
 class TestParseBindingValueTagKeys:

--- a/tests/unit/test_group_keys.py
+++ b/tests/unit/test_group_keys.py
@@ -1,26 +1,14 @@
 """Unit tests for matter/group_keys.py.
 
-Covers the pure read-modify-write GroupKeyMap merge logic. The device I/O
-(KeySetWrite via chip.clusters, attribute writes) is covered by the integration
-tests, since chip.clusters is only available in the real runtime.
+Covers the pure read-modify-write GroupKeyMap merge logic and the readback
+predicate. Entry encoding (key format + fabricIndex) and the write/verify/retry
+mechanism live in matter/wire.py and are covered by test_wire.py.
 """
 
 from custom_components.matter_binding_helper.matter.group_keys import (
     _group_key_map_has,
-    _unwrap_attr_list,
     merge_group_key_map,
 )
-
-
-def test_unwrap_attr_list_handles_path_wrapped_and_bare():
-    path = "0/63/0"
-    # read_attribute may wrap the value as {path: value} ...
-    assert _unwrap_attr_list({path: [{"1": 1}]}, path) == [{"1": 1}]
-    # ... or return the bare list ...
-    assert _unwrap_attr_list([{"1": 1}], path) == [{"1": 1}]
-    # ... or nothing usable.
-    assert _unwrap_attr_list(None, path) == []
-    assert _unwrap_attr_list({path: []}, path) == []
 
 
 def test_group_key_map_has_with_tag_keyed_entries():
@@ -40,15 +28,15 @@ def test_group_key_map_has_detects_mapping():
 
 
 def test_merge_into_empty_map():
+    # Logical entries: no fabricIndex / key encoding (that is wire's job).
     result = merge_group_key_map(None, group_id=5, key_set_id=0x100)
-    # Default fabric index is the accessing fabric (1-based), not 0.
-    assert result == [{"groupId": 5, "groupKeySetID": 0x100, "fabricIndex": 1}]
+    assert result == [{"groupId": 5, "groupKeySetID": 0x100}]
 
 
 def test_merge_appends_new_group():
     existing = [{"groupId": 1, "groupKeySetID": 0x100, "fabricIndex": 1}]
     result = merge_group_key_map(existing, group_id=2, key_set_id=0x101)
-    assert {"groupId": 2, "groupKeySetID": 0x101, "fabricIndex": 1} in result
+    assert {"groupId": 2, "groupKeySetID": 0x101} in result
     assert any(e["groupId"] == 1 for e in result)
     assert len(result) == 2
 
@@ -56,28 +44,13 @@ def test_merge_appends_new_group():
 def test_merge_is_idempotent_for_same_group():
     existing = [{"groupId": 5, "groupKeySetID": 0x100, "fabricIndex": 1}]
     result = merge_group_key_map(existing, group_id=5, key_set_id=0x100)
-    assert result == [{"groupId": 5, "groupKeySetID": 0x100, "fabricIndex": 1}]
+    assert result == [{"groupId": 5, "groupKeySetID": 0x100}]
 
 
 def test_merge_updates_key_set_for_existing_group():
     existing = [{"groupId": 5, "groupKeySetID": 0x100, "fabricIndex": 1}]
     result = merge_group_key_map(existing, group_id=5, key_set_id=0x200)
-    assert result == [{"groupId": 5, "groupKeySetID": 0x200, "fabricIndex": 1}]
-
-
-def test_merge_emits_tag_keys_when_requested():
-    """matter.js only persists numeric TLV tag keys on the list write."""
-    result = merge_group_key_map(None, group_id=5, key_set_id=0x100, tag_keys=True)
-    assert result == [{"1": 5, "2": 0x100, "254": 1}]
-
-
-def test_merge_uses_supplied_fabric_index():
-    """The accessing fabric index is honoured on every written entry."""
-    existing = [{"groupId": 1, "groupKeySetID": 0x100, "fabricIndex": 2}]
-    result = merge_group_key_map(
-        existing, group_id=2, key_set_id=0x101, fabric_index=2
-    )
-    assert all(e["fabricIndex"] == 2 for e in result)
+    assert result == [{"groupId": 5, "groupKeySetID": 0x200}]
 
 
 def test_merge_reads_chip_style_struct_entries():
@@ -90,11 +63,19 @@ def test_merge_reads_chip_style_struct_entries():
 
     existing = [FakeEntry(1, 0x100)]
     result = merge_group_key_map(existing, group_id=2, key_set_id=0x101)
-    assert {"groupId": 1, "groupKeySetID": 0x100, "fabricIndex": 1} in result
-    assert {"groupId": 2, "groupKeySetID": 0x101, "fabricIndex": 1} in result
+    assert {"groupId": 1, "groupKeySetID": 0x100} in result
+    assert {"groupId": 2, "groupKeySetID": 0x101} in result
+
+
+def test_merge_reads_tag_keyed_existing_entries():
+    """Existing entries from a device readback are keyed by numeric TLV tag."""
+    existing = [{"1": 1, "2": 0x100, "254": 1}]
+    result = merge_group_key_map(existing, group_id=2, key_set_id=0x101)
+    assert {"groupId": 1, "groupKeySetID": 0x100} in result
+    assert {"groupId": 2, "groupKeySetID": 0x101} in result
 
 
 def test_merge_skips_malformed_entries():
     existing = [{"groupId": None, "groupKeySetID": 5}, {"foo": "bar"}]
     result = merge_group_key_map(existing, group_id=9, key_set_id=0x100)
-    assert result == [{"groupId": 9, "groupKeySetID": 0x100, "fabricIndex": 1}]
+    assert result == [{"groupId": 9, "groupKeySetID": 0x100}]

--- a/tests/unit/test_wire.py
+++ b/tests/unit/test_wire.py
@@ -1,0 +1,187 @@
+"""Unit tests for matter/wire.py — the fabric-scoped write mechanism.
+
+A small fake stands in for the two real backends so the camelCase/tag-key +
+fabricIndex + cache-lag logic is exercised in milliseconds instead of a 9-minute
+real-device e2e run.
+"""
+
+import pytest
+
+from custom_components.matter_binding_helper.matter.wire import (
+    CURRENT_FABRIC_INDEX_PATH,
+    encode_struct,
+    struct_field,
+    unwrap_attr_list,
+    write_fabric_scoped_list,
+)
+
+# GroupKeyMap field tags for the tests.
+TAG_MAP = {"groupId": 1, "groupKeySetID": 2}
+
+
+class FakeServer:
+    """Simulates a Matter server's fabric-scoped list write semantics.
+
+    backend="python": accepts any key format, coerces fabricIndex to the
+      accessing fabric (like chip).
+    backend="matterjs": persists only numeric tag-key entries whose fabricIndex
+      equals the accessing fabric; silently drops anything else.
+    ``lag`` reads after a write return the prior value (cache lag).
+    """
+
+    def __init__(self, backend, accessing_fabric=1, lag=0):
+        self.backend = backend
+        self.fabric = accessing_fabric
+        self.lag = lag
+        self.store: list = []
+        self._stale = []
+        self._lag_left = 0
+
+    async def read_attribute(self, node_id, attribute_path):
+        if attribute_path == CURRENT_FABRIC_INDEX_PATH:
+            return {attribute_path: self.fabric}
+        if self._lag_left > 0:
+            self._lag_left -= 1
+            return {attribute_path: list(self._stale)}
+        return {attribute_path: list(self.store)}
+
+    async def write_attribute(self, node_id, attribute_path, value):
+        self._stale = list(self.store)
+        accepted = [e for e in (self._accept(e) for e in value) if e is not None]
+        self.store = accepted
+        self._lag_left = self.lag
+
+    def _accept(self, entry):
+        is_tag = all(k.isdigit() for k in entry)
+        fabric = entry.get("254") if is_tag else entry.get("fabricIndex")
+        if self.backend == "matterjs":
+            if not is_tag or fabric != self.fabric:
+                return None  # dropped, no error (matches observed behavior)
+            return entry
+        # python: accept, coerce fabric index
+        out = dict(entry)
+        out["254" if is_tag else "fabricIndex"] = self.fabric
+        return out
+
+
+def _has_group(group_id, key_set_id):
+    def verify(readback):
+        return any(
+            struct_field(e, "groupId", 1) == group_id
+            and struct_field(e, "groupKeySetID", 2) == key_set_id
+            for e in readback
+        )
+
+    return verify
+
+
+def test_encode_struct_name_vs_tag():
+    fields = {"groupId": 5, "groupKeySetID": 0x100}
+    assert encode_struct(fields, TAG_MAP, 1, tag_keys=False) == {
+        "groupId": 5,
+        "groupKeySetID": 0x100,
+        "fabricIndex": 1,
+    }
+    assert encode_struct(fields, TAG_MAP, 1, tag_keys=True) == {
+        "1": 5,
+        "2": 0x100,
+        "254": 1,
+    }
+
+
+def test_encode_struct_drops_none():
+    out = encode_struct({"groupId": 5, "groupKeySetID": None}, TAG_MAP, 2, False)
+    assert out == {"groupId": 5, "fabricIndex": 2}
+
+
+def test_unwrap_attr_list():
+    assert unwrap_attr_list({"0/63/0": [{"1": 1}]}, "0/63/0") == [{"1": 1}]
+    assert unwrap_attr_list([{"1": 1}], "0/63/0") == [{"1": 1}]
+    assert unwrap_attr_list(None, "0/63/0") == []
+
+
+@pytest.mark.asyncio
+async def test_write_succeeds_on_python_with_name_keys():
+    server = FakeServer("python")
+    ok, _ = await write_fabric_scoped_list(
+        server,
+        1,
+        "0/63/0",
+        [{"groupId": 1, "groupKeySetID": 0x100}],
+        TAG_MAP,
+        _has_group(1, 0x100),
+    )
+    assert ok
+    # python stored the entry (camelCase accepted on the first attempt)
+    assert server.store and struct_field(server.store[0], "groupId", 1) == 1
+
+
+@pytest.mark.asyncio
+async def test_write_retries_tag_keys_on_matterjs():
+    server = FakeServer("matterjs")
+    ok, _ = await write_fabric_scoped_list(
+        server,
+        1,
+        "0/63/0",
+        [{"groupId": 1, "groupKeySetID": 0x100}],
+        TAG_MAP,
+        _has_group(1, 0x100),
+        delay=0,
+    )
+    assert ok
+    # matter.js only kept the tag-keyed retry, with the real fabric index
+    assert server.store == [{"1": 1, "2": 0x100, "254": 1}]
+
+
+@pytest.mark.asyncio
+async def test_matterjs_accepts_real_fabric_index():
+    # If the code wrote fabricIndex 0 instead of the accessing fabric, matter.js
+    # would drop every entry and the write would never verify.
+    server = FakeServer("matterjs", accessing_fabric=1)
+    ok, _ = await write_fabric_scoped_list(
+        server,
+        1,
+        "0/63/0",
+        [{"groupId": 1, "groupKeySetID": 0x100}],
+        TAG_MAP,
+        _has_group(1, 0x100),
+        delay=0,
+    )
+    assert ok  # passes because we resolve and write the real fabric index (1)
+
+
+@pytest.mark.asyncio
+async def test_write_polls_through_cache_lag():
+    server = FakeServer("python", lag=3)
+    ok, _ = await write_fabric_scoped_list(
+        server,
+        1,
+        "0/63/0",
+        [{"groupId": 1, "groupKeySetID": 0x100}],
+        TAG_MAP,
+        _has_group(1, 0x100),
+        delay=0,  # no real sleeping in the test
+    )
+    assert ok
+
+
+@pytest.mark.asyncio
+async def test_write_fails_when_never_persisted():
+    # A server that drops everything: the write can never verify (both formats
+    # tried, all attempts polled) and returns failure rather than hanging.
+    class DropAll(FakeServer):
+        def _accept(self, entry):
+            return None
+
+    drop = DropAll("matterjs")
+    ok, last = await write_fabric_scoped_list(
+        drop,
+        1,
+        "0/63/0",
+        [{"groupId": 1, "groupKeySetID": 0x100}],
+        TAG_MAP,
+        _has_group(1, 0x100),
+        delay=0,
+    )
+    assert not ok
+    assert last == []


### PR DESCRIPTION
Second of the #61 series (after #309). Builds on the `MatterClientProtocol` seam to pull the python↔matter.js wire-format handling into one tested place.

## What

The matter.js compatibility work (#308) left the same mechanism duplicated across `group_keys` and `bindings`: camelCase↔tag-key encoding, resolving the real `fabricIndex`, `{path:value}` unwrap, cache-lag poll, and the write→verify→retry loop. This extracts it into **`matter/wire.py`**:

- `encode_struct` / `struct_field` / `unwrap_attr(_list)` / `current_fabric_index`
- `write_fabric_scoped_list(client, node, path, entries, tag_map, verify, *, read_entries=…)` — writes camelCase, polls the readback, retries with tag keys; `read_entries` lets a caller verify through its own reader.

Callers become declarative:
- `group_keys.provision_group_key` → give the GroupKeyMap field→tag map + a "mapping present" predicate.
- `bindings.create_binding` / `delete_binding` → give the Binding field→tag map; **still verify through `get_bindings`** (read path unchanged).

Net: `group_keys` −123 and `bindings` −49 lines; the logic lives in `wire.py`.

## The testability payoff (the point of the series)

`wire` works against the seam, so the mechanism is now unit-tested with a **fake server simulating both backends** — python (camelCase + fabricIndex coercion, lenient) vs matter.js (strict tag keys + literal fabricIndex + silent drops) + cache lag. The exact bugs from #308 are now millisecond regression tests:
- camelCase dropped on matter.js → retry tag keys
- `fabricIndex 0` rejected → write the real accessing fabric
- cache lag → poll instead of single read

## Test plan

- [x] 233 unit tests pass (8 new `test_wire.py`, against the fake backends)
- [x] `ruff check`/`format` clean
- [ ] Full matrix (integration + e2e both backends) green — the behavior-preservation safety net