### PR TITLE
feat(#61): optional direct connection to a non-default Matter server (PR 3/4)

### DIFF
--- a/custom_components/matter_binding_helper/__init__.py
+++ b/custom_components/matter_binding_helper/__init__.py
@@ -45,13 +45,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {}
 
-    # Check if Matter integration is available (skip in demo mode)
-    from .const import CONF_DEMO_MODE, DEFAULT_DEMO_MODE
+    from .const import (
+        CONF_DEMO_MODE,
+        CONF_MATTER_SERVER_URL,
+        DEFAULT_DEMO_MODE,
+        DEFAULT_MATTER_SERVER_URL,
+    )
 
     demo_mode = entry.options.get(CONF_DEMO_MODE, DEFAULT_DEMO_MODE)
-    if not demo_mode and not hass.config_entries.async_entries(MATTER_DOMAIN):
+    server_url = (
+        entry.options.get(CONF_MATTER_SERVER_URL, DEFAULT_MATTER_SERVER_URL) or ""
+    ).strip()
+
+    # In live mode we need a Matter client: either a directly-configured server
+    # URL (#61) or HA's own Matter integration.
+    if (
+        not demo_mode
+        and not server_url
+        and not hass.config_entries.async_entries(MATTER_DOMAIN)
+    ):
         _LOGGER.error("Matter integration is not set up")
         return False
+
+    # Optional direct connection to a non-default / development server (#61).
+    if not demo_mode and server_url:
+        from homeassistant.exceptions import ConfigEntryNotReady
+
+        from .matter.connection import DirectMatterConnection
+
+        connection = DirectMatterConnection(hass, server_url)
+        try:
+            await connection.async_connect()
+        except Exception as err:  # noqa: BLE001 - surfaced as ConfigEntryNotReady
+            raise ConfigEntryNotReady(
+                f"Could not connect to Matter server at {server_url}: {err}"
+            ) from err
+        hass.data[DOMAIN][entry.entry_id]["connection"] = connection
 
     # Register the frontend panel
     await _async_register_panel(hass)
@@ -94,6 +123,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         # Remove services
         hass.services.async_remove(DOMAIN, "submit_survey")
+
+        # Tear down the optional direct Matter connection (#61).
+        entry_data = hass.data[DOMAIN].get(entry.entry_id, {})
+        connection = entry_data.get("connection")
+        if connection is not None:
+            await connection.async_disconnect()
 
         # Clean up stored data
         hass.data[DOMAIN].pop(entry.entry_id, None)

--- a/custom_components/matter_binding_helper/config_flow.py
+++ b/custom_components/matter_binding_helper/config_flow.py
@@ -17,8 +17,10 @@ from homeassistant.components.matter import DOMAIN as MATTER_DOMAIN
 
 from .const import (
     CONF_DEMO_MODE,
+    CONF_MATTER_SERVER_URL,
     CONF_TELEMETRY_ENABLED,
     DEFAULT_DEMO_MODE,
+    DEFAULT_MATTER_SERVER_URL,
     DEFAULT_TELEMETRY_ENABLED,
     DOMAIN,
 )
@@ -108,6 +110,15 @@ class MatterBindingHelperOptionsFlow(OptionsFlowWithConfigEntry):
                         CONF_DEMO_MODE,
                         default=self.options.get(CONF_DEMO_MODE, DEFAULT_DEMO_MODE),
                     ): bool,
+                    # Optional: connect directly to this Matter server WS URL
+                    # (e.g. ws://localhost:5580/ws). Empty = use HA's Matter
+                    # integration. Must point at the same server/fabric (#61).
+                    vol.Optional(
+                        CONF_MATTER_SERVER_URL,
+                        default=self.options.get(
+                            CONF_MATTER_SERVER_URL, DEFAULT_MATTER_SERVER_URL
+                        ),
+                    ): str,
                 }
             ),
         )

--- a/custom_components/matter_binding_helper/const.py
+++ b/custom_components/matter_binding_helper/const.py
@@ -7,6 +7,10 @@ CONF_DEMO_MODE = "demo_mode"
 DEFAULT_DEMO_MODE = False
 CONF_TELEMETRY_ENABLED = "telemetry_enabled"
 DEFAULT_TELEMETRY_ENABLED = True  # Opt-out model: enabled by default
+# Optional override: connect directly to this Matter server WebSocket URL instead
+# of using Home Assistant's Matter integration client (issue #61). Empty = use HA.
+CONF_MATTER_SERVER_URL = "matter_server_url"
+DEFAULT_MATTER_SERVER_URL = ""
 
 # Telemetry settings
 TELEMETRY_URL = "https://matter-survey.org/api/submit"

--- a/custom_components/matter_binding_helper/matter/client.py
+++ b/custom_components/matter_binding_helper/matter/client.py
@@ -148,12 +148,29 @@ class RealMatterClient(MatterClientProtocol):
         return await self._client.send_command(command, **kwargs)
 
 
+def _get_direct_client(hass: HomeAssistant) -> "RealMatterServerClient | None":
+    """Return a directly-configured Matter client, if one is connected (#61)."""
+    from ..const import DOMAIN
+
+    for data in hass.data.get(DOMAIN, {}).values():
+        connection = data.get("connection") if isinstance(data, dict) else None
+        if connection is not None and connection.client is not None:
+            return connection.client
+    return None
+
+
 def get_raw_matter_client(hass: HomeAssistant) -> "RealMatterServerClient | None":
     """Get the raw Matter client from Home Assistant.
 
-    This returns the actual python-matter-server client instance,
-    not the wrapped protocol. Use get_client() for the protocol version.
+    Prefers an explicitly-configured direct connection (issue #61) and otherwise
+    falls back to the client owned by HA's Matter integration. Returns the actual
+    python-matter-server client instance, not the wrapped protocol; use
+    get_client() for the protocol version.
     """
+    direct = _get_direct_client(hass)
+    if direct is not None:
+        return direct
+
     try:
         from homeassistant.components.matter import DOMAIN as MATTER_DOMAIN
     except ImportError:

--- a/custom_components/matter_binding_helper/matter/connection.py
+++ b/custom_components/matter_binding_helper/matter/connection.py
@@ -1,0 +1,87 @@
+"""Optional direct connection to a Matter server (issue #61).
+
+By default the integration uses the Matter client owned by Home Assistant's
+Matter integration. When a server URL is configured, it instead connects
+directly to that server — useful for a non-default location, a development
+server, or as a fallback when reaching into HA's Matter integration breaks.
+
+The configured URL must point at the same Matter server (controller / fabric)
+the user otherwise runs, or commissioned devices will not be visible.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+_LOGGER = logging.getLogger(__name__)
+
+# How long to wait for the server to push its initial node state after connect.
+LISTEN_READY_TIMEOUT = 30
+
+
+class DirectMatterConnection:
+    """Owns a directly-connected matter-server client and its listen task."""
+
+    def __init__(self, hass: HomeAssistant, url: str) -> None:
+        self._hass = hass
+        self._url = url
+        self._client: Any = None
+        self._listen_task: asyncio.Task | None = None
+        self._ready = False
+
+    @property
+    def client(self) -> Any:
+        """The connected client, or None until it is ready."""
+        return self._client if self._ready else None
+
+    async def async_connect(self) -> None:
+        """Connect and wait for the server's initial state.
+
+        Raises on connection failure or if the server never becomes ready, after
+        cleaning up — the caller turns that into ConfigEntryNotReady.
+        """
+        # Imported lazily: python-matter-server is provided by HA's Matter
+        # integration (a hard dependency of this integration).
+        from matter_server.client import MatterClient
+
+        self._client = MatterClient(self._url, async_get_clientsession(self._hass))
+        await self._client.connect()
+
+        init_ready = asyncio.Event()
+        self._listen_task = self._hass.async_create_background_task(
+            self._listen(init_ready), "matter_binding_helper_direct_listen"
+        )
+        try:
+            async with asyncio.timeout(LISTEN_READY_TIMEOUT):
+                await init_ready.wait()
+        except TimeoutError:
+            await self.async_disconnect()
+            raise
+        self._ready = True
+        _LOGGER.info("Connected directly to Matter server at %s", self._url)
+
+    async def _listen(self, init_ready: asyncio.Event) -> None:
+        try:
+            await self._client.start_listening(init_ready)
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001 - logged; reconnect is HA's job
+            _LOGGER.warning("Direct Matter client listener stopped: %s", err)
+
+    async def async_disconnect(self) -> None:
+        """Cancel the listen task and disconnect the client."""
+        self._ready = False
+        if self._listen_task is not None:
+            self._listen_task.cancel()
+            self._listen_task = None
+        if self._client is not None:
+            try:
+                await self._client.disconnect()
+            except Exception as err:  # noqa: BLE001 - best-effort teardown
+                _LOGGER.debug("Error disconnecting direct Matter client: %s", err)
+            self._client = None

--- a/custom_components/matter_binding_helper/strings.json
+++ b/custom_components/matter_binding_helper/strings.json
@@ -31,11 +31,13 @@
         "description": "Configure the Matter Binding Helper integration.",
         "data": {
           "telemetry_enabled": "Share anonymized device data",
-          "demo_mode": "Demo Mode"
+          "demo_mode": "Demo Mode",
+          "matter_server_url": "Matter server URL (optional)"
         },
         "data_description": {
           "telemetry_enabled": "Share anonymous device capability data with matter-survey.org to help improve binding suggestions",
-          "demo_mode": "Enable demo mode to show mock Matter devices for UI development. Disable when using real Matter devices."
+          "demo_mode": "Enable demo mode to show mock Matter devices for UI development. Disable when using real Matter devices.",
+          "matter_server_url": "Connect directly to this Matter server (e.g. ws://localhost:5580/ws) instead of Home Assistant's Matter integration. Leave empty to use Home Assistant. Must point at the same server/fabric."
         }
       }
     }

--- a/custom_components/matter_binding_helper/translations/en.json
+++ b/custom_components/matter_binding_helper/translations/en.json
@@ -31,11 +31,13 @@
         "description": "Configure the Matter Binding Helper integration.",
         "data": {
           "telemetry_enabled": "Share anonymized device data",
-          "demo_mode": "Demo Mode"
+          "demo_mode": "Demo Mode",
+          "matter_server_url": "Matter server URL (optional)"
         },
         "data_description": {
           "telemetry_enabled": "Share anonymous device capability data with matter-survey.org to help improve binding suggestions",
-          "demo_mode": "Enable demo mode to show mock Matter devices for UI development. Disable when using real Matter devices."
+          "demo_mode": "Enable demo mode to show mock Matter devices for UI development. Disable when using real Matter devices.",
+          "matter_server_url": "Connect directly to this Matter server (e.g. ws://localhost:5580/ws) instead of Home Assistant's Matter integration. Leave empty to use Home Assistant. Must point at the same server/fabric."
         }
       }
     }

--- a/tests/unit/test_direct_connection.py
+++ b/tests/unit/test_direct_connection.py
@@ -1,0 +1,113 @@
+"""Unit tests for the optional direct Matter server connection (#61)."""
+
+import asyncio
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.matter_binding_helper.const import DOMAIN
+from custom_components.matter_binding_helper.matter.client import (
+    _get_direct_client,
+    get_raw_matter_client,
+)
+
+
+def _hass(data):
+    hass = MagicMock()
+    hass.data = data
+    return hass
+
+
+def test_direct_client_returned_when_connected():
+    conn = MagicMock()
+    conn.client = "SENTINEL"
+    assert _get_direct_client(_hass({DOMAIN: {"e1": {"connection": conn}}})) == "SENTINEL"
+
+
+def test_direct_client_none_when_not_ready():
+    conn = MagicMock()
+    conn.client = None
+    assert _get_direct_client(_hass({DOMAIN: {"e1": {"connection": conn}}})) is None
+
+
+def test_direct_client_none_when_absent():
+    assert _get_direct_client(_hass({DOMAIN: {"e1": {}}})) is None
+    assert _get_direct_client(_hass({})) is None
+
+
+def test_get_raw_matter_client_prefers_direct():
+    conn = MagicMock()
+    conn.client = "DIRECT"
+    # A configured direct client wins without touching HA's Matter integration.
+    assert get_raw_matter_client(_hass({DOMAIN: {"e1": {"connection": conn}}})) == "DIRECT"
+
+
+class _FakeMatterClient:
+    def __init__(self, url, session):
+        self.url = url
+        self.connected = False
+        self.listening = False
+
+    async def connect(self):
+        self.connected = True
+
+    async def start_listening(self, init_ready):
+        self.listening = True
+        init_ready.set()
+        await asyncio.Event().wait()  # block like the real read loop
+
+    async def disconnect(self):
+        self.connected = False
+
+
+@pytest.fixture
+def _fake_matter_server(monkeypatch):
+    pkg = types.ModuleType("matter_server")
+    client_mod = types.ModuleType("matter_server.client")
+    client_mod.MatterClient = _FakeMatterClient
+    pkg.client = client_mod
+    monkeypatch.setitem(sys.modules, "matter_server", pkg)
+    monkeypatch.setitem(sys.modules, "matter_server.client", client_mod)
+    import custom_components.matter_binding_helper.matter.connection as connection
+
+    monkeypatch.setattr(connection, "async_get_clientsession", lambda hass: MagicMock())
+    return connection
+
+
+@pytest.mark.asyncio
+async def test_connection_connects_and_disconnects(_fake_matter_server):
+    connection = _fake_matter_server
+    hass = MagicMock()
+    hass.async_create_background_task = lambda coro, name: asyncio.ensure_future(coro)
+
+    conn = connection.DirectMatterConnection(hass, "ws://localhost:5580/ws")
+    assert conn.client is None  # not ready until connected
+
+    await conn.async_connect()
+    assert conn.client is not None
+    assert conn.client.connected and conn.client.listening
+
+    await conn.async_disconnect()
+    assert conn.client is None
+
+
+@pytest.mark.asyncio
+async def test_connection_times_out_when_never_ready(_fake_matter_server):
+    connection = _fake_matter_server
+    connection.LISTEN_READY_TIMEOUT = 0.05  # don't wait 30s in the test
+
+    class _NeverReady(_FakeMatterClient):
+        async def start_listening(self, init_ready):
+            await asyncio.Event().wait()  # never sets init_ready
+
+    sys.modules["matter_server.client"].MatterClient = _NeverReady
+
+    hass = MagicMock()
+    hass.async_create_background_task = lambda coro, name: asyncio.ensure_future(coro)
+    conn = connection.DirectMatterConnection(hass, "ws://localhost:5580/ws")
+
+    with pytest.raises(TimeoutError):
+        await conn.async_connect()
+    assert conn.client is None  # cleaned up


### PR DESCRIPTION
Closes #61. Third of the series — the user-facing feature, built on the seam (#309) and the centralized wire layer (#311).

## What

By default the integration uses the Matter client owned by Home Assistant's Matter integration. This adds an optional **"Matter server URL"** option (options flow). When set, the integration connects **directly** to that server — useful for a non-default location, a development server, or as a fallback when reaching into HA's Matter integration breaks.

- **`matter/connection.py`** — `DirectMatterConnection` owns the client + listen task: `connect`, wait for initial state (30s timeout), `disconnect`.
- **`__init__.py`** — sets the connection up in `async_setup_entry` (raising `ConfigEntryNotReady` on failure) and tears it down on unload. Live mode now needs **either** a server URL **or** HA's Matter integration.
- **`client.get_raw_matter_client`** — prefers the direct client, else falls back to HA's Matter integration. Thanks to the seam (#309), **every device-I/O caller picks this up for free**.
- Options flow field + `strings.json`/`translations`.

## Architecture note (override/fallback model)

The configured URL must point at the **same** Matter server (controller/fabric) HA otherwise uses, or commissioned devices won't be visible. This is the agreed "override/fallback" model — not a separate controller.

## Tests

Unit-tested with a faked `matter_server` client:
- `get_raw_matter_client` prefers a connected direct client; falls back otherwise.
- Connection lifecycle: connect → ready → disconnect, and the ready-timeout cleanup path.

The default (HA-integration) path is covered by the existing integration + e2e matrix (behavior unchanged when no URL is set). A real-server direct-connection integration test is a good follow-up (PR 4 testing pass).

## Test plan

- [x] 239 unit tests pass (6 new), `ruff`/`format` clean, JSON valid
- [ ] Full matrix green — confirms the default path is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional direct Matter server WebSocket connection configuration as an alternative to Home Assistant's built-in Matter integration
  * New configuration options to enable demo mode and specify a custom Matter server URL
  * Improved connection handling with proper setup and teardown

* **Tests**
  * Added comprehensive unit test coverage for direct connection functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->