### PR TITLE
test: device-less ACL flow tests via a FakeMatterClient (PR 4/4)

### DIFF
--- a/tests/unit/fake_matter.py
+++ b/tests/unit/fake_matter.py
@@ -1,0 +1,94 @@
+"""A device-less fake of the raw python-matter-server client.
+
+Simulates the two backends' fabric-scoped + set_acl_entry semantics so the
+higher-level flows (write_acl, …) can be exercised in milliseconds. It mimics
+the *raw* client surface that ``RealMatterClient`` wraps, so it plugs into the
+integration via the direct-connection slot:
+
+    hass.data[DOMAIN] = {"e": {"connection": SimpleNamespace(client=fake)}}
+
+``backend="python"`` accepts camelCase ACL keys (chip); ``backend="matterjs"``
+reads snake_case (``auth_mode`` / target ``device_type``) and rejects an entry
+with CONSTRAINT_ERROR when those keys are absent — exactly the divergence the
+dual-key fix targets.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+CONSTRAINT_ERROR = 0x87  # 135
+
+
+class FakeNode:
+    def __init__(self, node_id: int, available: bool = True) -> None:
+        self.node_id = node_id
+        self.available = available
+        self.endpoints: dict[int, Any] = {}
+
+
+class FakeMatterClient:
+    """Raw-style fake Matter client for device-less flow tests."""
+
+    def __init__(
+        self,
+        backend: str = "python",
+        node_ids: tuple[int, ...] = (1,),
+        fabric_index: int = 1,
+    ) -> None:
+        self.backend = backend
+        self.fabric = fabric_index
+        self._nodes = [FakeNode(n) for n in node_ids]
+        self.attrs: dict[tuple[int, str], Any] = {}
+        self.acl: dict[int, list[dict[str, Any]]] = {}
+
+    # --- raw client surface -------------------------------------------------
+    def get_nodes(self) -> list[FakeNode]:
+        return self._nodes
+
+    async def read_attribute(self, node_id: int, attribute_path: str) -> Any:
+        if attribute_path.endswith(
+            "/62/5"
+        ):  # OperationalCredentials.CurrentFabricIndex
+            return {attribute_path: self.fabric}
+        if attribute_path.endswith("/31/0"):  # AccessControl.ACL
+            return {attribute_path: list(self.acl.get(node_id, []))}
+        return {attribute_path: self.attrs.get((node_id, attribute_path), [])}
+
+    async def write_attribute(self, node_id: int, attribute_path: str, value: Any):
+        self.attrs[(node_id, attribute_path)] = value
+
+    async def send_command(self, command: str, **kwargs: Any) -> Any:
+        if command == "set_acl_entry":
+            return self._set_acl_entry(kwargs["node_id"], kwargs["entry"])
+        raise NotImplementedError(command)
+
+    # --- set_acl_entry simulation ------------------------------------------
+    def _set_acl_entry(
+        self, node_id: int, entries: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        results = []
+        normalized = []
+        for entry in entries:
+            status = self._acl_status(entry)
+            results.append({"Status": status})
+            if status == 0:
+                normalized.append(entry)
+        if all(r["Status"] == 0 for r in results):
+            self.acl[node_id] = normalized
+        return results
+
+    def _acl_status(self, entry: dict[str, Any]) -> int:
+        if self.backend == "matterjs":
+            # matter.js reads snake_case auth_mode and target device_type; absence
+            # of those keys yields a malformed entry the device rejects.
+            if "auth_mode" not in entry:
+                return CONSTRAINT_ERROR
+            for target in entry.get("targets") or []:
+                if "device_type" not in target and target.get("endpoint") is not None:
+                    return CONSTRAINT_ERROR
+            return 0
+        # python-matter-server (chip) reads camelCase.
+        if "authMode" not in entry:
+            return CONSTRAINT_ERROR
+        return 0

--- a/tests/unit/test_acl_flow.py
+++ b/tests/unit/test_acl_flow.py
@@ -1,0 +1,83 @@
+"""Device-less tests for the ACL write flow against both simulated backends.
+
+These lock in the dual-key set_acl_entry fix (matter.js reads snake_case
+auth_mode / device_type) as millisecond regression tests rather than a 9-minute
+real-device e2e run.
+"""
+
+from types import SimpleNamespace
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.matter_binding_helper.const import DOMAIN
+from custom_components.matter_binding_helper.matter.acl import (
+    build_group_acl_entry,
+    write_acl,
+)
+
+from .fake_matter import FakeMatterClient
+
+CLUSTER_ON_OFF = 6
+ADMIN_ENTRY = {
+    "privilege": 5,  # Administer
+    "authMode": 2,
+    "auth_mode": 2,
+    "subjects": [112233],
+    "targets": None,
+    "fabricIndex": 0,
+}
+
+
+def _hass(fake: FakeMatterClient):
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"e1": {"connection": SimpleNamespace(client=fake)}}}
+    # No config entries -> is_demo_mode() returns falsy (live mode).
+    hass.config_entries.async_entries = lambda domain: []
+    return hass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["python", "matterjs"])
+async def test_write_group_acl_succeeds_on_both_backends(backend):
+    fake = FakeMatterClient(backend=backend)
+    group_entry = build_group_acl_entry(
+        group_id=1, cluster_id=CLUSTER_ON_OFF, target_endpoint_id=1
+    )
+    result = await write_acl(
+        _hass(fake), node_id=1, acl_entries=[ADMIN_ENTRY, group_entry]
+    )
+
+    assert result.success, result.message
+    assert len(fake.acl[1]) == 2  # admin + group-auth entry persisted
+
+
+@pytest.mark.asyncio
+async def test_camelcase_only_group_acl_is_rejected_by_matterjs():
+    """A pre-dual-key entry (camelCase only) reproduces the CONSTRAINT_ERROR."""
+    fake = FakeMatterClient(backend="matterjs")
+    legacy_entry = {
+        "privilege": 3,
+        "authMode": 3,  # Group — but no snake_case auth_mode
+        "subjects": [1],
+        "targets": [{"cluster": CLUSTER_ON_OFF, "endpoint": 1, "deviceType": None}],
+        "fabricIndex": 0,
+    }
+    result = await write_acl(
+        _hass(fake), node_id=1, acl_entries=[ADMIN_ENTRY, legacy_entry]
+    )
+
+    assert not result.success
+    assert "rejected" in result.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_write_acl_safety_blocks_without_admin():
+    fake = FakeMatterClient(backend="python")
+    group_entry = build_group_acl_entry(group_id=1, cluster_id=CLUSTER_ON_OFF)
+    result = await write_acl(_hass(fake), node_id=1, acl_entries=[group_entry])
+
+    assert not result.success
+    assert "admin" in result.message.lower()
+    assert 1 not in fake.acl  # nothing written


### PR DESCRIPTION
Final PR of the #61 series — the testability payoff made concrete.

## What

Adds a raw-style **`FakeMatterClient`** (`tests/unit/fake_matter.py`) that simulates both backends' `set_acl_entry` semantics and plugs into the integration via the #61 direct-connection slot (`hass.data[DOMAIN][…]["connection"].client = fake`). Uses it to exercise `write_acl` end-to-end **without a device**:

- a **dual-key** group-auth ACL writes successfully on **both** python and matter.js
- a **camelCase-only** entry reproduces matter.js's `CONSTRAINT_ERROR (135)` — the exact bug the dual-key fix (#308) addresses, now a **millisecond regression test**
- the admin-entry safety block is covered

## Why this is the payoff

Before this series, verifying any of this took a ~9-minute real-device e2e run. The seam (#309) + centralized wire layer (#311) made the client injectable, so device logic is now testable in milliseconds. This PR demonstrates the pattern on the ACL flow (chip-free); it extends naturally to the groups/bindings flows with the chip command builders mocked — a good follow-up.

## Test plan

- [x] 243 unit tests pass (4 new), `ruff`/`format` clean
- [ ] Full matrix green (no production code changed — tests only)