### PR TITLE
chore: sync hacs.json Home Assistant floor

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Matter Binding Helper",
-  "homeassistant": "2026.8.1",
+  "homeassistant": "2026.8.2",
   "render_readme": true,
   "zip_release": true,
   "filename": "matter_binding_helper.zip"


### PR DESCRIPTION
Auto-generated: aligns hacs.json's `homeassistant` minimum with the requirements.txt floor after it changed on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required Home Assistant version to 2026.8.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->